### PR TITLE
fix(ci): improve GitHub release metadata

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-09T20:35:21.453Z for PR creation at branch issue-6-79b9bc4dc763 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/6

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T20:35:21.453Z for PR creation at branch issue-6-79b9bc4dc763 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/6

--- a/changelog.d/20260509_204000_issue_6_release_metadata.md
+++ b/changelog.d/20260509_204000_issue_6_release_metadata.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- GitHub release creation now supports configurable tag prefixes, language-labeled release titles, and automatic PyPI badge insertion when release notes do not already contain a shields.io badge.

--- a/scripts/create_github_release.py
+++ b/scripts/create_github_release.py
@@ -3,10 +3,12 @@
 Create a GitHub release from CHANGELOG.md content.
 
 Usage:
-    python scripts/create_github_release.py --version VERSION --repository REPO
+    python scripts/create_github_release.py --version VERSION --repository REPO \
+        [--tag-prefix PREFIX] [--language LANGUAGE]
 
 Example:
-    python scripts/create_github_release.py --version 1.2.3 --repository owner/repo
+    python scripts/create_github_release.py --version 1.2.3 --repository owner/repo \
+        --tag-prefix python_v --language Python
 
 Environment variables:
     GH_TOKEN or GITHUB_TOKEN: GitHub token for authentication
@@ -71,14 +73,30 @@ def extract_changelog_entry(changelog_path: Path, version: str) -> str:
     return entry if entry else f"Release {version}"
 
 
+def append_pypi_badge_if_missing(release_notes: str, version: str) -> str:
+    """Append a PyPI version badge unless a shields.io badge is already present."""
+    if "img.shields.io" in release_notes.lower():
+        return release_notes
+
+    badge = f"![PyPI](https://img.shields.io/badge/pypi-{version}-blue.svg)"
+    return f"{release_notes.rstrip()}\n\n{badge}"
+
+
 def create_release(
-    version: str, repository: str, release_notes: str, prerelease: bool = False
+    version: str,
+    repository: str,
+    release_notes: str,
+    prerelease: bool = False,
+    tag_prefix: str = "v",
+    language: str = "Python",
 ) -> None:
     """Create a GitHub release using gh CLI."""
-    tag = f"v{version}"
+    tag = f"{tag_prefix}{version}"
+    title = f"[{language}] {version}"
 
     print(f"\nCreating GitHub release for {tag}...")
     print(f"Repository: {repository}")
+    print(f"Title: {title}")
     print(f"Prerelease: {prerelease}")
     print(f"\nRelease notes:\n{release_notes}\n")
 
@@ -90,7 +108,7 @@ def create_release(
         "--repo",
         repository,
         "--title",
-        tag,
+        title,
         "--notes",
         release_notes,
     ]
@@ -124,6 +142,16 @@ def main() -> int:
         action="store_true",
         help="Mark as prerelease",
     )
+    parser.add_argument(
+        "--tag-prefix",
+        default="v",
+        help='Tag prefix for the release (default "v")',
+    )
+    parser.add_argument(
+        "--language",
+        default="Python",
+        help='Language label for the release title (default "Python")',
+    )
 
     args = parser.parse_args()
 
@@ -150,11 +178,17 @@ def main() -> int:
     changelog_path = project_root / "CHANGELOG.md"
 
     try:
-        # Extract changelog entry
         release_notes = extract_changelog_entry(changelog_path, args.version)
+        release_notes = append_pypi_badge_if_missing(release_notes, args.version)
 
-        # Create release
-        create_release(args.version, args.repository, release_notes, args.prerelease)
+        create_release(
+            args.version,
+            args.repository,
+            release_notes,
+            args.prerelease,
+            args.tag_prefix,
+            args.language,
+        )
 
         return 0
 

--- a/tests/test_create_github_release.py
+++ b/tests/test_create_github_release.py
@@ -1,0 +1,69 @@
+"""Tests for scripts/create_github_release.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent / "scripts" / "create_github_release.py"
+)
+spec = importlib.util.spec_from_file_location("create_github_release", SCRIPT_PATH)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)  # type: ignore[union-attr]
+
+
+def test_create_release_uses_tag_prefix_and_language_title(monkeypatch) -> None:
+    """Release creation should separate tag format from display title."""
+    commands = []
+
+    def fake_run_command(cmd, check=True):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(module, "run_command", fake_run_command)
+
+    module.create_release(
+        version="1.2.3",
+        repository="owner/repo",
+        release_notes="Release notes",
+        prerelease=False,
+        tag_prefix="python_v",
+        language="Python",
+    )
+
+    assert commands == [
+        [
+            "gh",
+            "release",
+            "create",
+            "python_v1.2.3",
+            "--repo",
+            "owner/repo",
+            "--title",
+            "[Python] 1.2.3",
+            "--notes",
+            "Release notes",
+        ],
+    ]
+
+
+def test_append_pypi_badge_if_missing_adds_static_version_badge() -> None:
+    """Release notes should get a PyPI badge before gh creates the release."""
+    body = module.append_pypi_badge_if_missing("Release notes", "1.2.3")
+
+    assert "Release notes" in body
+    assert "https://img.shields.io/badge/pypi-1.2.3-blue.svg" in body
+
+
+def test_append_pypi_badge_if_missing_does_not_duplicate_badge() -> None:
+    """Existing shields.io badges should be preserved without duplication."""
+    existing = (
+        "Release notes\n\n![PyPI](https://img.shields.io/badge/pypi-1.2.3-blue.svg)"
+    )
+
+    assert module.append_pypi_badge_if_missing(existing, "1.2.3") == existing


### PR DESCRIPTION
Fixes #6

## Summary

Updates `scripts/create_github_release.py` so GitHub releases no longer use the bare tag as the display title and release notes include a PyPI shields.io badge when one is missing.

## Changes

- Added `--tag-prefix` with default `v`, so consumers can produce tags such as `python_v1.2.3` without editing the script.
- Added `--language` with default `Python`, so release titles are created as `[Python] 1.2.3` or another configured language label.
- Appended `https://img.shields.io/badge/pypi-{version}-blue.svg` to release notes when the body has no existing `img.shields.io` reference.
- Added a changelog fragment and removed the temporary `.gitkeep` placeholder commit artifact.

## Reproduction And Verification

The new `tests/test_create_github_release.py` reproduces the issue by asserting that release creation uses a configurable tag prefix, a language-labeled title, and automatic PyPI badge insertion without duplicating existing shields.io badges.

Local checks run:

- `pytest` - 12 passed
- `ruff check .` - passed
- `ruff format --check .` - passed
- `mypy src/` - passed, with mypy warning that the installed mypy version no longer supports configured `python_version = 3.9`
- `python scripts/check_file_size.py` - passed
- `python scripts/create_github_release.py --help` - verified CLI options
- `python -m build` - passed
- `twine check dist/*` - passed

No UI changes; screenshots are not applicable.
