### PR TITLE
docs: track preview regeneration parity

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-15T07:40:14.625Z for PR creation at branch issue-8-7a513b3d2cbf for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/8
-# Updated: 2026-05-29T22:25:36.855Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-15T07:40:14.625Z for PR creation at branch issue-8-7a513b3d2cbf for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/8
+# Updated: 2026-05-29T22:25:36.855Z

--- a/README.md
+++ b/README.md
@@ -223,6 +223,15 @@ for the bug this guards against).
 `actions/deploy-pages` with `Get Pages site failed`. This cannot be configured
 from a workflow.
 
+### Preview regeneration parity
+
+[Issue #9](https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/9)
+tracks parity with the browser preview-regeneration pattern from the JavaScript
+template. This Python template does not ship a browser-rendered example app, so
+it intentionally does not install Playwright or add a screenshot workflow yet.
+When such a surface is added, use the Python porting checklist in
+[`docs/preview-regeneration.md`](docs/preview-regeneration.md).
+
 ### Release Automation
 
 The release workflow (`release.yml`) provides:

--- a/changelog.d/20260529_222900_issue_9_preview_regeneration.md
+++ b/changelog.d/20260529_222900_issue_9_preview_regeneration.md
@@ -1,0 +1,4 @@
+### Added
+
+- Documented preview-regeneration parity tracking for issue #9, including the
+  activation criteria for a future `playwright-python` screenshot workflow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ with your project name, author, and the autodoc target package.
 :caption: Contents
 
 api
+preview-regeneration
 ```
 
 ## Indices

--- a/docs/preview-regeneration.md
+++ b/docs/preview-regeneration.md
@@ -1,0 +1,57 @@
+# Preview Regeneration Parity
+
+[Issue #9](https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/9)
+tracks parity with the preview-regeneration pattern from
+[link-foundation/js-ai-driven-development-pipeline-template#62](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/62).
+The JavaScript template uses `browser-commander` with Playwright to refresh
+README, GitHub Pages, and Open Graph preview images from a real browser render.
+
+## Current Status
+
+This Python template does not ship a browser-rendered example app. It currently
+contains a package scaffold, release tooling, examples, and Sphinx API docs, but
+no UI surface whose screenshots can drift. For that reason the template
+intentionally does not add Playwright dependencies, browser binary installation,
+or a no-op screenshot workflow yet.
+
+`browser-commander` is JavaScript-only. When this template gains a browser app
+surface, port the pattern with
+[`playwright-python`](https://playwright.dev/python/) directly instead of adding
+Node-only tooling to the Python template.
+
+## Activation Criteria
+
+Add preview-regeneration automation when the template includes at least one of:
+
+- A README or documentation screenshot generated from an example app UI.
+- A GitHub Pages site with static preview images.
+- An `og:image` or social sharing image generated from app state.
+- A browser-rendered example that has a meaningful locale x theme matrix.
+
+Until one of those surfaces exists, documentation-only tracking is the intended
+state for issue #9.
+
+## Python Port Checklist
+
+When a browser-rendered example app is added, the port should include:
+
+1. A script such as `scripts/update_preview_images.py` that serves the built
+   app locally and drives Chromium with `playwright-python`.
+2. A deterministic matrix for locale x theme captures, matching the JavaScript
+   template's intent while using Python-native APIs.
+3. Generated screenshots under `docs/screenshots/` or another documented
+   location that README and docs reference directly.
+4. Verbose diagnostics behind `PREVIEW_VERBOSE=1`, including resolved URL,
+   locale, theme, page title, and screenshot dimensions.
+5. CI drift detection using `git status --porcelain`, with expected screenshot
+   paths staged explicitly before any automatic commit.
+6. Failure artifacts for generated screenshots and Playwright traces so CI
+   failures are diagnosable without rerunning locally.
+
+## Workflow Policy
+
+The future workflow should run on `push` to `main` and `workflow_dispatch`.
+Pull requests should either verify the screenshot script without committing
+drift, or upload generated images as artifacts for review. If a push-to-main
+job commits refreshed images, use `[skip ci]` to avoid an infinite workflow
+loop and stage only generated preview artifacts.

--- a/tests/test_preview_regeneration_docs.py
+++ b/tests/test_preview_regeneration_docs.py
@@ -1,0 +1,31 @@
+"""Tests for preview-regeneration parity documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def read_text(relative_path: str) -> str:
+    """Read a repository file as text."""
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_preview_regeneration_parity_is_documented() -> None:
+    """Issue #9 should remain tracked until a browser app surface exists."""
+    page = read_text("docs/preview-regeneration.md")
+
+    assert "python-ai-driven-development-pipeline-template/issues/9" in page
+    assert "js-ai-driven-development-pipeline-template/issues/62" in page
+    assert "playwright-python" in page
+    assert "browser-commander" in page
+    assert "does not ship a browser-rendered example app" in page
+    assert "locale x theme" in page
+
+
+def test_preview_regeneration_docs_are_discoverable() -> None:
+    """The tracking page should be reachable from docs and README."""
+    assert "preview-regeneration" in read_text("docs/index.md")
+    assert "docs/preview-regeneration.md" in read_text("README.md")


### PR DESCRIPTION
Fixes #9.

## Summary

Adds durable tracking for the browser preview-regeneration parity pattern without adding premature browser automation to this Python template.

- Adds `docs/preview-regeneration.md` with the current no-browser-surface decision, activation criteria, and a future `playwright-python` port checklist.
- Links the tracking page from the Sphinx docs index and README so the issue is discoverable from generated docs and repository docs.
- Adds regression coverage that fails when the tracking page or discoverability links are removed.
- Adds a changelog fragment and removes the autogenerated `.gitkeep` placeholder.

## Why no Playwright workflow yet

Issue #9 explicitly notes that this template has no example-app surface today. The template currently ships package tooling, examples, and Sphinx API docs, but no browser-rendered UI whose screenshots can drift. The new docs record when to add automation and how to port the JavaScript `browser-commander` pattern using Python-native Playwright APIs once such a surface exists.

## Reproduction and Verification

Before the docs were added, `pytest tests/test_preview_regeneration_docs.py -q` failed because `docs/preview-regeneration.md` did not exist and the docs index did not link any tracking page.

Checks run:

- `pytest tests/test_preview_regeneration_docs.py -q`
- `pytest`
- `ruff check .`
- `ruff format --check .`
- `mypy src/` (passes; emits the existing mypy config warning about `python_version = 3.9` under the installed mypy)
- `python scripts/check_file_size.py`
- `sphinx-build -W --keep-going -b html docs _site`
- `python -m build`
- `python -m twine check dist/*`
- `git diff --cached --check`

No UI changes; screenshots are not applicable.
