### PR TITLE
Docs: guard current GitHub Actions pins

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-29T22:59:23.162Z for PR creation at branch issue-12-2788671b9000 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/12

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-29T22:59:23.162Z for PR creation at branch issue-12-2788671b9000 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/12

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -38,6 +38,12 @@ def assert_action_pin_count(
     assert len(re.findall(pattern, workflow)) == count
 
 
+def assert_action_pin_absent(workflow: str, action: str, version: str) -> None:
+    """Assert an outdated action reference is not used."""
+    pattern = rf"uses:\s+{re.escape(action)}@{re.escape(version)}\b"
+    assert not re.search(pattern, workflow)
+
+
 def test_release_workflow_keeps_main_releases_running() -> None:
     """Main release runs must not be cancelled by follow-up pushes."""
     workflow = read_workflow("release.yml")
@@ -65,17 +71,27 @@ def test_release_workflow_jobs_have_explicit_timeouts() -> None:
         assert f"timeout-minutes: {timeout}" in block
 
 
-def test_workflow_action_versions_are_current() -> None:
-    """Workflow actions should use the current major versions."""
+def test_release_workflow_action_versions_are_current() -> None:
+    """Release workflow actions should use the current major versions."""
     release_workflow = read_workflow("release.yml")
-    docs_workflow = read_workflow("docs.yml")
 
     assert_action_pin_count(release_workflow, "actions/checkout", "v6", 7)
     assert_action_pin_count(release_workflow, "actions/upload-artifact", "v7", 1)
     assert_action_pin_count(release_workflow, "actions/download-artifact", "v7", 1)
+
+
+def test_docs_workflow_action_versions_are_current() -> None:
+    """Docs workflow actions should stay aligned with the current Pages stack."""
+    docs_workflow = read_workflow("docs.yml")
 
     assert_action_pin_count(docs_workflow, "actions/checkout", "v6", 1)
     assert_action_pin_count(docs_workflow, "actions/upload-artifact", "v7", 1)
     assert_action_pin_count(docs_workflow, "actions/configure-pages", "v6", 1)
     assert_action_pin_count(docs_workflow, "actions/upload-pages-artifact", "v5", 1)
     assert_action_pin_count(docs_workflow, "actions/deploy-pages", "v5", 1)
+
+    assert_action_pin_absent(docs_workflow, "actions/checkout", "v4")
+    assert_action_pin_absent(docs_workflow, "actions/upload-artifact", "v4")
+    assert_action_pin_absent(docs_workflow, "actions/configure-pages", "v5")
+    assert_action_pin_absent(docs_workflow, "actions/upload-pages-artifact", "v3")
+    assert_action_pin_absent(docs_workflow, "actions/deploy-pages", "v4")


### PR DESCRIPTION
## Summary

Fixes #12.

- Confirms `.github/workflows/docs.yml` is already on the requested current action stack from PR #14: `checkout@v6`, `upload-artifact@v7`, `configure-pages@v6`, `upload-pages-artifact@v5`, and `deploy-pages@v5`.
- Adds explicit regression coverage so the old issue #12 pins (`checkout@v4`, `upload-artifact@v4`, `configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`) cannot reappear unnoticed.
- Removes the autogenerated placeholder `.gitkeep` from the prepared branch diff.

## Reproduction

On the pre-PR #14 workflow state described in issue #12, `python -m pytest tests/test_workflows.py -q` fails because the docs workflow is pinned to the older action majors. The new docs-specific test now checks both the current pins and the stale pins called out in the issue.

## Verification

- `python -m pytest tests/test_workflows.py -q`
- `python -m pytest`
- `ruff check .`
- `ruff format --check .`
- `mypy src/`
- `python scripts/check_file_size.py`
- `git diff --check`

Note: `mypy src/` passed while emitting the repository's existing config warnings about `python_version = "3.9"` and deprecated `--strict-concatenate`.
