### PR TITLE
fix(ci): cap GitHub release notes

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-04T17:58:35.346Z for PR creation at branch issue-16-d0d762c26af7 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/16

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-04T17:58:35.346Z for PR creation at branch issue-16-d0d762c26af7 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/16

--- a/changelog.d/20260604_170000_issue_16_release_notes_limit.md
+++ b/changelog.d/20260604_170000_issue_16_release_notes_limit.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- GitHub release creation now caps generated release notes to a conservative
+  UTF-8 byte limit and links to the full tagged `CHANGELOG.md` when truncation
+  is needed.

--- a/scripts/create_github_release.py
+++ b/scripts/create_github_release.py
@@ -22,6 +22,10 @@ import sys
 from pathlib import Path
 
 
+MAX_RELEASE_NOTES_BYTES = 60_000
+ENCODING = "utf-8"
+
+
 def run_command(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
     """Run a command and handle errors."""
     print(f"Running: {' '.join(cmd)}")
@@ -82,6 +86,53 @@ def append_pypi_badge_if_missing(release_notes: str, version: str) -> str:
     return f"{release_notes.rstrip()}\n\n{badge}"
 
 
+def release_notes_size(release_notes: str) -> int:
+    """Return the UTF-8 byte size of release notes."""
+    return len(release_notes.encode(ENCODING))
+
+
+def truncate_to_bytes(text: str, max_bytes: int) -> str:
+    """Truncate text to a UTF-8 byte limit without splitting a character."""
+    encoded = text.encode(ENCODING)
+    if len(encoded) <= max_bytes:
+        return text
+
+    return encoded[:max_bytes].decode(ENCODING, errors="ignore")
+
+
+def build_changelog_url(repository: str, tag: str) -> str:
+    """Build a link to the changelog file at the release tag."""
+    return f"https://github.com/{repository}/blob/{tag}/CHANGELOG.md"
+
+
+def cap_release_notes(
+    release_notes: str,
+    repository: str,
+    tag: str,
+    max_bytes: int = MAX_RELEASE_NOTES_BYTES,
+) -> str:
+    """Cap release notes to a conservative byte limit and link the full changelog."""
+    if release_notes_size(release_notes) <= max_bytes:
+        return release_notes
+
+    notice = (
+        "\n\n---\n\n"
+        "Release notes were truncated because the changelog entry is too large "
+        "for GitHub Releases. See the full tagged CHANGELOG.md: "
+        f"{build_changelog_url(repository, tag)}"
+    )
+    notice_size = release_notes_size(notice)
+
+    if notice_size >= max_bytes:
+        return truncate_to_bytes(notice.lstrip(), max_bytes).rstrip()
+
+    preserved_notes = truncate_to_bytes(
+        release_notes.rstrip(),
+        max_bytes - notice_size,
+    ).rstrip()
+    return f"{preserved_notes}{notice}"
+
+
 def create_release(
     version: str,
     repository: str,
@@ -93,11 +144,19 @@ def create_release(
     """Create a GitHub release using gh CLI."""
     tag = f"{tag_prefix}{version}"
     title = f"[{language}] {version}"
+    original_notes_size = release_notes_size(release_notes)
+    release_notes = cap_release_notes(release_notes, repository, tag)
+    capped_notes_size = release_notes_size(release_notes)
 
     print(f"\nCreating GitHub release for {tag}...")
     print(f"Repository: {repository}")
     print(f"Title: {title}")
     print(f"Prerelease: {prerelease}")
+    if capped_notes_size < original_notes_size:
+        print(
+            "Release notes truncated from "
+            f"{original_notes_size} to {capped_notes_size} bytes",
+        )
     print(f"\nRelease notes:\n{release_notes}\n")
 
     cmd = [

--- a/tests/test_create_github_release.py
+++ b/tests/test_create_github_release.py
@@ -52,6 +52,41 @@ def test_create_release_uses_tag_prefix_and_language_title(monkeypatch) -> None:
     ]
 
 
+def test_create_release_caps_oversized_release_notes(monkeypatch) -> None:
+    """Release creation should avoid sending oversized notes to GitHub."""
+    commands = []
+    oversized_notes = (
+        "Important release summary\n\n"
+        + ("Multi-byte change entry: café\n" * 3_000)
+        + "\nTail marker that should be omitted"
+    )
+
+    def fake_run_command(cmd, check=True):
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(module, "run_command", fake_run_command)
+
+    module.create_release(
+        version="1.2.3",
+        repository="owner/repo",
+        release_notes=oversized_notes,
+        prerelease=False,
+        tag_prefix="python_v",
+        language="Python",
+    )
+
+    release_notes = commands[0][commands[0].index("--notes") + 1]
+
+    assert len(release_notes.encode("utf-8")) <= module.MAX_RELEASE_NOTES_BYTES
+    assert release_notes.startswith("Important release summary")
+    assert "Tail marker that should be omitted" not in release_notes
+    assert "Release notes were truncated" in release_notes
+    assert (
+        "https://github.com/owner/repo/blob/python_v1.2.3/CHANGELOG.md" in release_notes
+    )
+
+
 def test_append_pypi_badge_if_missing_adds_static_version_badge() -> None:
     """Release notes should get a PyPI badge before gh creates the release."""
     body = module.append_pypi_badge_if_missing("Release notes", "1.2.3")


### PR DESCRIPTION
Fixes #16.

## Summary

- Caps generated GitHub release notes to 60,000 UTF-8 bytes before invoking `gh release create`.
- Preserves the beginning of the changelog entry and appends a link to the full tagged `CHANGELOG.md` when truncation is needed.
- Adds regression coverage for oversized multi-byte release notes and a changelog fragment.

## Reproduction

Before the fix, `create_release` passed the extracted changelog body directly through to `gh release create --notes`. The new `test_create_release_caps_oversized_release_notes` reproduces the failure mode with an oversized changelog body and verifies the command payload stays under the byte cap, keeps the opening summary, omits the tail, and links to the tagged changelog.

## Verification

- `python -m pytest tests/test_create_github_release.py -q`
- `python -m pytest`
- `ruff check .`
- `ruff format --check .`
- `mypy src/` - passed with existing config warnings about `python_version = 3.9` and deprecated `--strict-concatenate`
- `python scripts/check_file_size.py`
- `git diff --check`
- `python scripts/create_github_release.py --help`

No UI changes; screenshots are not applicable.