### PR TITLE
fix: prevent manual release skip when detect-changes is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,14 +68,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [detect-changes]
+    # always() && !cancelled() lets this job evaluate even though detect-changes
+    # is skipped for workflow_dispatch; without it, the skipped dependency would
+    # propagate and skip lint despite the workflow_dispatch condition below.
     if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      needs.detect-changes.outputs.py-changed == 'true' ||
-      needs.detect-changes.outputs.tests-changed == 'true' ||
-      needs.detect-changes.outputs.docs-changed == 'true' ||
-      needs.detect-changes.outputs.package-changed == 'true' ||
-      needs.detect-changes.outputs.workflow-changed == 'true'
+      always() && !cancelled() && (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.py-changed == 'true' ||
+        needs.detect-changes.outputs.tests-changed == 'true' ||
+        needs.detect-changes.outputs.docs-changed == 'true' ||
+        needs.detect-changes.outputs.package-changed == 'true' ||
+        needs.detect-changes.outputs.workflow-changed == 'true'
+      )
     steps:
       - uses: actions/checkout@v6
 
@@ -108,13 +113,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [detect-changes]
+    # always() && !cancelled() lets this job evaluate even though detect-changes
+    # is skipped for workflow_dispatch; without it, the skipped dependency would
+    # propagate and skip test despite the workflow_dispatch condition below.
     if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      needs.detect-changes.outputs.py-changed == 'true' ||
-      needs.detect-changes.outputs.tests-changed == 'true' ||
-      needs.detect-changes.outputs.package-changed == 'true' ||
-      needs.detect-changes.outputs.workflow-changed == 'true'
+      always() && !cancelled() && (
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.py-changed == 'true' ||
+        needs.detect-changes.outputs.tests-changed == 'true' ||
+        needs.detect-changes.outputs.package-changed == 'true' ||
+        needs.detect-changes.outputs.workflow-changed == 'true'
+      )
     steps:
       - uses: actions/checkout@v6
 
@@ -294,7 +304,15 @@ jobs:
   manual-release:
     name: Manual Release
     needs: [lint, test, build]
-    if: github.event_name == 'workflow_dispatch'
+    # always() && !cancelled() prevents the skipped detect-changes dependency from
+    # propagating through lint/test/build and silently skipping the release.
+    # The explicit result checks ensure release only proceeds after CI passes.
+    if: |
+      always() && !cancelled() &&
+      github.event_name == 'workflow_dispatch' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success' &&
+      needs.build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-09T00:42:39.760Z for PR creation at branch issue-18-4b141eae3b82 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/18

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-09T00:42:39.760Z for PR creation at branch issue-18-4b141eae3b82 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/18

--- a/changelog.d/20260609_000000_issue_18_manual_release_skip.md
+++ b/changelog.d/20260609_000000_issue_18_manual_release_skip.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Manual `workflow_dispatch` releases no longer get silently skipped. The
+  `lint`, `test`, and `manual-release` jobs now use `always() && !cancelled()`
+  status-check functions so the intentionally skipped `detect-changes` job does
+  not propagate through `needs` and skip the release path. `manual-release` also
+  explicitly requires `lint`, `test`, and `build` to succeed before releasing.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -80,6 +80,47 @@ def test_release_workflow_action_versions_are_current() -> None:
     assert_action_pin_count(release_workflow, "actions/download-artifact", "v7", 1)
 
 
+STATUS_CHECK_FUNCTIONS = ("always()", "!cancelled()", "!failure()", "success()")
+
+
+def job_condition(workflow: str, job_name: str) -> str:
+    """Return the ``if:`` condition text for a workflow job."""
+    block = workflow_job_block(workflow, job_name)
+    match = re.search(r"^    if:(.*?)(?=^    [a-z])", block, re.DOTALL | re.MULTILINE)
+    assert match, f"job {job_name!r} has no if condition"
+    return match.group(1)
+
+
+def test_dispatch_dependent_jobs_use_status_check_function() -> None:
+    """Jobs that depend on skippable jobs must override the default status gate.
+
+    ``detect-changes`` is skipped for ``workflow_dispatch``. GitHub Actions skips
+    a job whose dependency was skipped unless the dependent ``if`` condition
+    includes a status-check function (``always()``, ``!cancelled()``, ...).
+    Without it, a manual release silently skips lint/test and then the release
+    itself even though it appears successful.
+    """
+    workflow = read_workflow("release.yml")
+
+    for job_name in ("lint", "test", "manual-release"):
+        condition = job_condition(workflow, job_name)
+        assert any(fn in condition for fn in STATUS_CHECK_FUNCTIONS), (
+            f"job {job_name!r} depends on a skippable job but its if condition "
+            f"does not start with a status-check function: {condition!r}"
+        )
+
+
+def test_manual_release_requires_required_checks_to_succeed() -> None:
+    """Manual release must only run after lint, test, and build succeed."""
+    workflow = read_workflow("release.yml")
+    condition = job_condition(workflow, "manual-release")
+
+    assert "needs.lint.result == 'success'" in condition
+    assert "needs.test.result == 'success'" in condition
+    assert "needs.build.result == 'success'" in condition
+    assert "github.event_name == 'workflow_dispatch'" in condition
+
+
 def test_docs_workflow_action_versions_are_current() -> None:
     """Docs workflow actions should stay aligned with the current Pages stack."""
     docs_workflow = read_workflow("docs.yml")


### PR DESCRIPTION
## Summary

Fixes #18 — a manually dispatched (`workflow_dispatch`) release in `.github/workflows/release.yml` could be silently skipped.

`detect-changes` is intentionally skipped for `workflow_dispatch`. GitHub Actions skips any job whose `needs` dependency was skipped **unless** the dependent job's `if` condition contains a status-check function (`always()`, `!cancelled()`, ...). The `lint`, `test`, and `manual-release` jobs used plain `if` conditions, so the skip propagated through `needs` and the release path never ran — while the run still appeared successful.

## Changes

- **`lint`** and **`test`**: wrapped the existing conditions in `always() && !cancelled() && ( ... )` so they still evaluate on `workflow_dispatch` despite the skipped `detect-changes` dependency. The inner boolean logic is unchanged, so push/PR behavior is identical.
- **`manual-release`**: condition is now
  ```yaml
  if: |
    always() && !cancelled() &&
    github.event_name == 'workflow_dispatch' &&
    needs.lint.result == 'success' &&
    needs.test.result == 'success' &&
    needs.build.result == 'success'
  ```
  so the release runs only after the required checks actually pass.
- Added a changelog fragment.

## Tests

Added workflow policy tests in `tests/test_workflows.py`:

- `test_dispatch_dependent_jobs_use_status_check_function` — asserts `lint`, `test`, and `manual-release` include a status-check function (regression guard against the skipped-needs class).
- `test_manual_release_requires_required_checks_to_succeed` — asserts `manual-release` explicitly requires `lint`/`test`/`build` success and the `workflow_dispatch` event.

All 21 tests pass locally; `ruff check`, `ruff format --check`, and YAML parsing are clean.

## Context

Same GitHub Actions skipped-needs behavior found while investigating link-foundation/command-stream#161, where split releases did not publish after merge.
