### PR TITLE
fix(ci): smoke test published PyPI package before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,12 @@ jobs:
         if: steps.version_check.outputs.should_release == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
 
+      - name: Smoke test published package
+        if: steps.version_check.outputs.should_release == 'true'
+        run: |
+          python scripts/smoke_test_published_package.py \
+            --version "${{ steps.version_check.outputs.current_version }}"
+
       - name: Create GitHub Release
         if: steps.version_check.outputs.should_release == 'true'
         env:
@@ -368,6 +374,12 @@ jobs:
       - name: Publish to PyPI
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Smoke test published package
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        run: |
+          python scripts/smoke_test_published_package.py \
+            --version "${{ steps.version.outputs.new_version }}"
 
       - name: Create GitHub Release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T10:33:11.094Z for PR creation at branch issue-20-5fb07642b93a for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/20

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T10:33:11.094Z for PR creation at branch issue-20-5fb07642b93a for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/20

--- a/README.md
+++ b/README.md
@@ -241,7 +241,9 @@ The release workflow (`release.yml`) provides:
 3. **Manual release**: Trigger releases via workflow_dispatch
 4. **Fragment collection**: Automatically collects changelog fragments
 5. **PyPI publishing**: OIDC trusted publishing (no tokens needed)
-6. **GitHub releases**: Automatic creation with CHANGELOG content
+6. **Published package smoke test**: Installs the just-published PyPI package
+   into a clean virtualenv and verifies imports/console scripts
+7. **GitHub releases**: Automatic creation with CHANGELOG content
 
 **Important**: All releases require passing CI checks (lint + test + build). No release will ever happen without passing tests, ensuring code quality and stability.
 

--- a/changelog.d/20260614_000000_issue_20_published_package_smoke_test.md
+++ b/changelog.d/20260614_000000_issue_20_published_package_smoke_test.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Release jobs now install the just-published PyPI package into a clean virtual
+  environment and smoke-test imports and declared console scripts before
+  creating the GitHub release. Console-script output is captured before preview
+  lines are printed, avoiding SIGPIPE-sensitive live pipelines such as
+  `command | head`.

--- a/scripts/smoke_test_published_package.py
+++ b/scripts/smoke_test_published_package.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Install and exercise a just-published Python package from an index."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - workflow runs on Python 3.13.
+    tomllib = None  # type: ignore[assignment]
+
+
+DEFAULT_INSTALL_ATTEMPTS = 6
+DEFAULT_INSTALL_DELAY_SECONDS = 20.0
+DEFAULT_PREVIEW_LINES = 20
+DEFAULT_SCRIPT_ARGS = ("--help",)
+
+
+class SmokeTestError(RuntimeError):
+    """Raised when the published package smoke test fails."""
+
+
+@dataclass(frozen=True)
+class PackageMetadata:
+    """Package metadata needed for the published install smoke test."""
+
+    distribution_name: str
+    import_names: list[str]
+    console_scripts: list[str]
+
+
+def format_command(cmd: list[str]) -> str:
+    """Return a shell-like command string for logs."""
+    return shlex.join(cmd)
+
+
+def print_stream(output: str, stream: Any = sys.stdout) -> None:
+    """Print subprocess output without adding an extra blank line."""
+    if output:
+        end = "" if output.endswith("\n") else "\n"
+        print(output, end=end, file=stream)
+
+
+def run_command(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+    echo_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command with captured output so previews never close live pipes."""
+    print(f"Running: {format_command(cmd)}")
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if echo_output:
+        print_stream(result.stdout)
+        print_stream(result.stderr, sys.stderr)
+
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            cmd,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+
+    return result
+
+
+def load_pyproject(pyproject_path: Path) -> dict[str, Any]:
+    """Load pyproject.toml with a structured TOML parser."""
+    if tomllib is None:
+        message = "smoke_test_published_package.py requires Python 3.11+"
+        raise SmokeTestError(message)
+
+    with pyproject_path.open("rb") as pyproject_file:
+        return tomllib.load(pyproject_file)
+
+
+def nested_mapping(mapping: dict[str, Any], *keys: str) -> dict[str, Any]:
+    """Return a nested mapping from TOML data, or an empty mapping."""
+    current: Any = mapping
+    for key in keys:
+        if not isinstance(current, dict):
+            return {}
+        current = current.get(key, {})
+    if isinstance(current, dict):
+        return current
+    return {}
+
+
+def import_names_from_wheel_packages(
+    config: dict[str, Any],
+    distribution_name: str,
+) -> list[str]:
+    """Derive import names from Hatch wheel package paths."""
+    wheel_target = nested_mapping(config, "tool", "hatch", "build", "targets", "wheel")
+    packages = wheel_target.get("packages", [])
+    import_names: list[str] = []
+
+    if isinstance(packages, list):
+        for package_path in packages:
+            if not isinstance(package_path, str):
+                continue
+            import_name = Path(package_path.replace("\\", "/")).name
+            if import_name and import_name not in import_names:
+                import_names.append(import_name)
+
+    if import_names:
+        return import_names
+
+    fallback_name = distribution_name.replace("-", "_").replace(".", "_")
+    if fallback_name.isidentifier():
+        return [fallback_name]
+
+    message = (
+        "could not derive an import name from pyproject.toml; "
+        "pass --import-name explicitly"
+    )
+    raise SmokeTestError(message)
+
+
+def package_metadata(
+    config: dict[str, Any],
+    *,
+    package_name_override: str | None = None,
+    import_name_overrides: list[str] | None = None,
+) -> PackageMetadata:
+    """Extract package metadata from pyproject.toml and CLI overrides."""
+    project = nested_mapping(config, "project")
+    distribution_name = package_name_override or str(project.get("name", "")).strip()
+    if not distribution_name:
+        message = "could not determine package name from pyproject.toml"
+        raise SmokeTestError(message)
+
+    scripts = project.get("scripts", {})
+    console_scripts = list(scripts) if isinstance(scripts, dict) else []
+    import_names = import_name_overrides or import_names_from_wheel_packages(
+        config,
+        distribution_name,
+    )
+
+    return PackageMetadata(
+        distribution_name=distribution_name,
+        import_names=import_names,
+        console_scripts=console_scripts,
+    )
+
+
+def venv_python(venv_dir: Path) -> Path:
+    """Return the Python executable for a virtual environment."""
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def venv_script(venv_dir: Path, script_name: str) -> Path:
+    """Return a console script path inside a virtual environment."""
+    scripts_dir = venv_dir / ("Scripts" if os.name == "nt" else "bin")
+    script_path = scripts_dir / script_name
+    if os.name == "nt" and not script_path.exists():
+        return script_path.with_suffix(".exe")
+    return script_path
+
+
+def create_virtualenv(venv_dir: Path) -> Path:
+    """Create a clean virtual environment and return its Python executable."""
+    run_command([sys.executable, "-m", "venv", str(venv_dir)])
+    python = venv_python(venv_dir)
+    run_command([str(python), "-m", "pip", "install", "--upgrade", "pip"])
+    return python
+
+
+def install_published_package(
+    python: Path,
+    package_name: str,
+    version: str,
+    *,
+    attempts: int,
+    delay_seconds: float,
+    index_url: str | None,
+) -> None:
+    """Install a published package, retrying while the package index catches up."""
+    if attempts < 1:
+        message = "--install-attempts must be at least 1"
+        raise SmokeTestError(message)
+
+    package_spec = f"{package_name}=={version}"
+    cmd = [
+        str(python),
+        "-m",
+        "pip",
+        "install",
+        "--no-cache-dir",
+        package_spec,
+    ]
+    if index_url:
+        cmd.extend(["--index-url", index_url])
+
+    for attempt in range(1, attempts + 1):
+        print(f"Installing {package_spec} (attempt {attempt}/{attempts})")
+        result = run_command(cmd, check=False)
+        if result.returncode == 0:
+            return
+        if attempt < attempts:
+            print(f"Install failed; retrying in {delay_seconds:g} seconds")
+            time.sleep(delay_seconds)
+
+    message = f"failed to install {package_spec} from the package index"
+    raise SmokeTestError(message)
+
+
+def verify_imports(python: Path, metadata: PackageMetadata, version: str) -> None:
+    """Import installed modules and verify distribution metadata version."""
+    for import_name in metadata.import_names:
+        code = "\n".join(
+            [
+                "import importlib",
+                "import importlib.metadata as metadata",
+                f"module = importlib.import_module({import_name!r})",
+                f"actual = metadata.version({metadata.distribution_name!r})",
+                f"expected = {version!r}",
+                "if actual != expected:",
+                "    raise SystemExit(f'version mismatch: {actual} != {expected}')",
+                "location = getattr(module, '__file__', '<unknown>')",
+                "print(f'imported {module.__name__} from {location}')",
+            ]
+        )
+        run_command([str(python), "-c", code])
+
+
+def preview_output(output: str, max_lines: int = DEFAULT_PREVIEW_LINES) -> str:
+    """Return a bounded preview from already-captured command output."""
+    if max_lines < 1:
+        return ""
+
+    lines = output.splitlines()
+    preview = "\n".join(lines[:max_lines])
+    remaining = len(lines) - max_lines
+    if remaining > 0:
+        preview = f"{preview}\n... ({remaining} more lines)"
+    return preview
+
+
+def print_preview(label: str, output: str, max_lines: int) -> None:
+    """Print a named preview of captured output."""
+    preview = preview_output(output, max_lines)
+    if preview:
+        print(f"{label}:\n{preview}")
+
+
+def verify_console_scripts(
+    venv_dir: Path,
+    script_names: list[str],
+    script_args: tuple[str, ...],
+    *,
+    preview_lines: int,
+) -> None:
+    """Run installed console scripts with captured output previews."""
+    if not script_names:
+        print("No console scripts declared; skipping CLI smoke tests")
+        return
+
+    for script_name in script_names:
+        cmd = [str(venv_script(venv_dir, script_name)), *script_args]
+        result = run_command(cmd, check=False, echo_output=False)
+        print_preview(f"{script_name} stdout preview", result.stdout, preview_lines)
+        print_preview(f"{script_name} stderr preview", result.stderr, preview_lines)
+
+        if result.returncode != 0:
+            message = f"console script {script_name!r} failed smoke test"
+            raise SmokeTestError(message)
+
+        if not (result.stdout.strip() or result.stderr.strip()):
+            message = f"console script {script_name!r} produced no output"
+            raise SmokeTestError(message)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Install and smoke-test a just-published package version",
+    )
+    parser.add_argument("--version", required=True, help="Published version to install")
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root containing pyproject.toml",
+    )
+    parser.add_argument(
+        "--package-name",
+        help="Distribution name override; defaults to project.name",
+    )
+    parser.add_argument(
+        "--import-name",
+        action="append",
+        dest="import_names",
+        help="Import name to verify; may be repeated",
+    )
+    parser.add_argument(
+        "--skip-console-scripts",
+        action="store_true",
+        help="Skip [project.scripts] smoke tests",
+    )
+    parser.add_argument(
+        "--script-arg",
+        action="append",
+        dest="script_args",
+        help="Argument passed to each console script; defaults to --help",
+    )
+    parser.add_argument(
+        "--install-attempts",
+        type=int,
+        default=DEFAULT_INSTALL_ATTEMPTS,
+        help="Number of pip install attempts while waiting for index propagation",
+    )
+    parser.add_argument(
+        "--install-delay-seconds",
+        type=float,
+        default=DEFAULT_INSTALL_DELAY_SECONDS,
+        help="Delay between package install attempts",
+    )
+    parser.add_argument(
+        "--preview-lines",
+        type=int,
+        default=DEFAULT_PREVIEW_LINES,
+        help="Maximum captured output lines to print for each console script",
+    )
+    parser.add_argument(
+        "--index-url",
+        default=None,
+        help="Package index URL override; defaults to pip configuration",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the published package smoke test."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    project_root = args.project_root.resolve()
+    pyproject_path = project_root / "pyproject.toml"
+    script_args = tuple(args.script_args or DEFAULT_SCRIPT_ARGS)
+
+    try:
+        config = load_pyproject(pyproject_path)
+        metadata = package_metadata(
+            config,
+            package_name_override=args.package_name,
+            import_name_overrides=args.import_names,
+        )
+
+        print(
+            "Smoke testing "
+            f"{metadata.distribution_name}=={args.version} "
+            f"with imports: {', '.join(metadata.import_names)}"
+        )
+
+        with tempfile.TemporaryDirectory(prefix="published-package-smoke-") as temp_dir:
+            temp_path = Path(temp_dir)
+            venv_dir = temp_path / "venv"
+            python = create_virtualenv(venv_dir)
+            install_published_package(
+                python,
+                metadata.distribution_name,
+                args.version,
+                attempts=args.install_attempts,
+                delay_seconds=args.install_delay_seconds,
+                index_url=args.index_url,
+            )
+            verify_imports(python, metadata, args.version)
+            if not args.skip_console_scripts:
+                verify_console_scripts(
+                    venv_dir,
+                    metadata.console_scripts,
+                    script_args,
+                    preview_lines=args.preview_lines,
+                )
+
+        print("Published package smoke test passed")
+        return 0
+    except (OSError, SmokeTestError, subprocess.CalledProcessError) as error:
+        print(f"Published package smoke test failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_smoke_test_published_package.py
+++ b/tests/test_smoke_test_published_package.py
@@ -1,0 +1,131 @@
+"""Tests for scripts/smoke_test_published_package.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "scripts"
+    / "smoke_test_published_package.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "smoke_test_published_package", SCRIPT_PATH
+)
+assert spec is not None
+assert spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+def test_package_metadata_derives_imports_and_scripts_from_pyproject() -> None:
+    """Smoke metadata should come from the package config by default."""
+    config = {
+        "project": {
+            "name": "my-package",
+            "scripts": {"my-cli": "my_package.cli:main"},
+        },
+        "tool": {
+            "hatch": {
+                "build": {
+                    "targets": {
+                        "wheel": {
+                            "packages": ["src/my_package"],
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    metadata = module.package_metadata(config)
+
+    assert metadata.distribution_name == "my-package"
+    assert metadata.import_names == ["my_package"]
+    assert metadata.console_scripts == ["my-cli"]
+
+
+def test_run_command_captures_output(monkeypatch) -> None:
+    """Commands should capture output instead of piping live output to pagers."""
+    run_kwargs = {}
+
+    def fake_run(cmd, **kwargs):
+        run_kwargs.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, "line 1\nline 2\n", "")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_command(["producer"], echo_output=False)
+
+    assert result.stdout == "line 1\nline 2\n"
+    assert run_kwargs["capture_output"] is True
+    assert run_kwargs["text"] is True
+    assert run_kwargs["check"] is False
+
+
+def test_install_published_package_retries_until_indexed(monkeypatch) -> None:
+    """Install should retry while a freshly published version propagates."""
+    commands = []
+    sleeps = []
+
+    def fake_run_command(cmd, **kwargs):
+        commands.append(cmd)
+        assert kwargs["check"] is False
+        return subprocess.CompletedProcess(cmd, 0 if len(commands) == 2 else 1, "", "")
+
+    monkeypatch.setattr(module, "run_command", fake_run_command)
+    monkeypatch.setattr(module.time, "sleep", sleeps.append)
+
+    module.install_published_package(
+        Path("/venv/bin/python"),
+        "my-package",
+        "1.2.3",
+        attempts=2,
+        delay_seconds=0.5,
+        index_url="https://example.test/simple",
+    )
+
+    assert len(commands) == 2
+    assert "my-package==1.2.3" in commands[0]
+    assert commands[0][-2:] == ["--index-url", "https://example.test/simple"]
+    assert sleeps == [0.5]
+
+
+def test_console_script_preview_uses_captured_output(
+    monkeypatch,
+    capsys,
+    tmp_path,
+) -> None:
+    """Console output previews should be taken from captured strings."""
+    commands = []
+    output = "\n".join(f"line {index}" for index in range(6))
+
+    def fake_run_command(cmd, **kwargs):
+        commands.append(cmd)
+        assert kwargs["check"] is False
+        assert kwargs["echo_output"] is False
+        return subprocess.CompletedProcess(cmd, 0, output, "")
+
+    monkeypatch.setattr(module, "run_command", fake_run_command)
+
+    module.verify_console_scripts(
+        tmp_path / "venv",
+        ["my-cli"],
+        ("--list",),
+        preview_lines=3,
+    )
+
+    captured = capsys.readouterr()
+
+    assert commands == [[str(tmp_path / "venv" / "bin" / "my-cli"), "--list"]]
+    assert "|" not in " ".join(commands[0])
+    assert "head" not in commands[0]
+    assert "line 0" in captured.out
+    assert "line 2" in captured.out
+    assert "line 3" not in captured.out
+    assert "... (3 more lines)" in captured.out

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -121,6 +121,27 @@ def test_manual_release_requires_required_checks_to_succeed() -> None:
     assert "github.event_name == 'workflow_dispatch'" in condition
 
 
+def test_release_jobs_smoke_test_published_package_before_github_release() -> None:
+    """Published packages must be installed and exercised before announcing release."""
+    workflow = read_workflow("release.yml")
+
+    expected_version_outputs = {
+        "auto-release": "steps.version_check.outputs.current_version",
+        "manual-release": "steps.version.outputs.new_version",
+    }
+
+    for job_name, version_output in expected_version_outputs.items():
+        block = workflow_job_block(workflow, job_name)
+        assert "- name: Smoke test published package" in block
+        assert "python scripts/smoke_test_published_package.py" in block
+        assert f'--version "${{{{ {version_output} }}}}"' in block
+
+        publish_index = block.index("- name: Publish to PyPI")
+        smoke_index = block.index("- name: Smoke test published package")
+        release_index = block.index("- name: Create GitHub Release")
+        assert publish_index < smoke_index < release_index
+
+
 def test_docs_workflow_action_versions_are_current() -> None:
     """Docs workflow actions should stay aligned with the current Pages stack."""
     docs_workflow = read_workflow("docs.yml")


### PR DESCRIPTION
## Summary

- Add `scripts/smoke_test_published_package.py` to create a clean virtualenv, retry installing the just-published `package==version` from the package index, verify imports, and exercise declared console scripts.
- Run the smoke test after PyPI publish and before GitHub release creation in both automatic and manual release paths.
- Keep console-script output previews SIGPIPE-safe by capturing command output first, then printing bounded preview lines from the captured string.
- Document the release behavior and add a changelog fragment.

Fixes #20

## Reproduction

Before this change, `release.yml` published to PyPI and immediately created the GitHub release. The new regression test `test_release_jobs_smoke_test_published_package_before_github_release` failed because there was no clean install-from-package smoke-test step between `Publish to PyPI` and `Create GitHub Release`.

## Tests

- `.venv/bin/pytest`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mypy src/` (passes; local mypy 2.1 reports a compatibility warning for the repo's configured Python 3.9 target)
- `.venv/bin/python scripts/check_file_size.py`
- `.venv/bin/python scripts/smoke_test_published_package.py --help`
- `.venv/bin/python -m build && .venv/bin/twine check dist/*`

No UI changes; screenshots are not applicable.
