### PR TITLE
Support Python releases in multi-language monorepos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,38 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Detect Python layout
+        id: python_layout
+        run: |
+          if [ -f pyproject.toml ]; then
+            PYTHON_ROOT="."
+            MULTI_LANGUAGE="false"
+            echo "root=." >> "$GITHUB_OUTPUT"
+            echo "multi_language=false" >> "$GITHUB_OUTPUT"
+          elif [ -f python/pyproject.toml ]; then
+            PYTHON_ROOT="python"
+            MULTI_LANGUAGE="true"
+            echo "root=python" >> "$GITHUB_OUTPUT"
+            echo "multi_language=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not find pyproject.toml at repo root or python/pyproject.toml"
+            exit 1
+          fi
+
+          if [ "$PYTHON_ROOT" = "." ]; then
+            echo "dist_dir=dist" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_dir=$PYTHON_ROOT/dist" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected Python layout: root=$PYTHON_ROOT, multi_language=$MULTI_LANGUAGE"
+
       - name: Detect changes
         id: changes
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: python scripts/detect_code_changes.py
+        run: python "${{ steps.python_layout.outputs.root }}/scripts/detect_code_changes.py"
 
   # REQUIRED CI CHECKS - All must pass before release
   # These jobs ensure code quality and tests pass before any release
@@ -89,22 +114,56 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Detect Python layout
+        id: python_layout
+        run: |
+          if [ -f pyproject.toml ]; then
+            PYTHON_ROOT="."
+            MULTI_LANGUAGE="false"
+            echo "root=." >> "$GITHUB_OUTPUT"
+            echo "multi_language=false" >> "$GITHUB_OUTPUT"
+          elif [ -f python/pyproject.toml ]; then
+            PYTHON_ROOT="python"
+            MULTI_LANGUAGE="true"
+            echo "root=python" >> "$GITHUB_OUTPUT"
+            echo "multi_language=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not find pyproject.toml at repo root or python/pyproject.toml"
+            exit 1
+          fi
+
+          if [ "$PYTHON_ROOT" = "." ]; then
+            echo "dist_dir=dist" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_dir=$PYTHON_ROOT/dist" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected Python layout: root=$PYTHON_ROOT, multi_language=$MULTI_LANGUAGE"
+
       - name: Install dependencies
         run: |
+          cd "${{ steps.python_layout.outputs.root }}"
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
       - name: Run Ruff linting
-        run: ruff check .
+        run: |
+          cd "${{ steps.python_layout.outputs.root }}"
+          ruff check .
 
       - name: Check Ruff formatting
-        run: ruff format --check .
+        run: |
+          cd "${{ steps.python_layout.outputs.root }}"
+          ruff format --check .
 
       - name: Run mypy
-        run: mypy src
+        run: |
+          cd "${{ steps.python_layout.outputs.root }}"
+          mypy src
 
       - name: Check file size limit
-        run: python scripts/check_file_size.py
+        run: |
+          cd "${{ steps.python_layout.outputs.root }}"
+          python scripts/check_file_size.py
 
   # === TEST ===
   # Test on latest Python version only
@@ -133,13 +192,41 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Detect Python layout
+        id: python_layout
+        run: |
+          if [ -f pyproject.toml ]; then
+            PYTHON_ROOT="."
+            MULTI_LANGUAGE="false"
+            echo "root=." >> "$GITHUB_OUTPUT"
+            echo "multi_language=false" >> "$GITHUB_OUTPUT"
+          elif [ -f python/pyproject.toml ]; then
+            PYTHON_ROOT="python"
+            MULTI_LANGUAGE="true"
+            echo "root=python" >> "$GITHUB_OUTPUT"
+            echo "multi_language=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not find pyproject.toml at repo root or python/pyproject.toml"
+            exit 1
+          fi
+
+          if [ "$PYTHON_ROOT" = "." ]; then
+            echo "dist_dir=dist" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_dir=$PYTHON_ROOT/dist" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected Python layout: root=$PYTHON_ROOT, multi_language=$MULTI_LANGUAGE"
+
       - name: Install dependencies
         run: |
+          cd "${{ steps.python_layout.outputs.root }}"
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest tests/ -v --cov=src --cov-report=xml --cov-report=term
+        run: |
+          cd "${{ steps.python_layout.outputs.root }}"
+          pytest tests/ -v --cov=src --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -172,22 +259,51 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Detect Python layout
+        id: python_layout
+        run: |
+          if [ -f pyproject.toml ]; then
+            PYTHON_ROOT="."
+            MULTI_LANGUAGE="false"
+            echo "root=." >> "$GITHUB_OUTPUT"
+            echo "multi_language=false" >> "$GITHUB_OUTPUT"
+          elif [ -f python/pyproject.toml ]; then
+            PYTHON_ROOT="python"
+            MULTI_LANGUAGE="true"
+            echo "root=python" >> "$GITHUB_OUTPUT"
+            echo "multi_language=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not find pyproject.toml at repo root or python/pyproject.toml"
+            exit 1
+          fi
+
+          if [ "$PYTHON_ROOT" = "." ]; then
+            echo "dist_dir=dist" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_dir=$PYTHON_ROOT/dist" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected Python layout: root=$PYTHON_ROOT, multi_language=$MULTI_LANGUAGE"
+
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build twine
 
       - name: Build package
-        run: python -m build
+        run: |
+          cd "${{ steps.python_layout.outputs.root }}"
+          python -m build
 
       - name: Check package
-        run: twine check dist/*
+        run: |
+          cd "${{ steps.python_layout.outputs.root }}"
+          twine check dist/*
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
           name: dist
-          path: dist/
+          path: ${{ steps.python_layout.outputs.dist_dir }}
 
   # === CHANGELOG CHECK - only runs on PRs with code changes ===
   # Docs-only PRs (./docs folder, markdown files) don't require changelog fragments
@@ -207,19 +323,53 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Detect Python layout
+        id: python_layout
+        run: |
+          if [ -f pyproject.toml ]; then
+            PYTHON_ROOT="."
+            MULTI_LANGUAGE="false"
+            echo "root=." >> "$GITHUB_OUTPUT"
+            echo "multi_language=false" >> "$GITHUB_OUTPUT"
+          elif [ -f python/pyproject.toml ]; then
+            PYTHON_ROOT="python"
+            MULTI_LANGUAGE="true"
+            echo "root=python" >> "$GITHUB_OUTPUT"
+            echo "multi_language=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not find pyproject.toml at repo root or python/pyproject.toml"
+            exit 1
+          fi
+
+          if [ "$PYTHON_ROOT" = "." ]; then
+            echo "dist_dir=dist" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_dir=$PYTHON_ROOT/dist" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected Python layout: root=$PYTHON_ROOT, multi_language=$MULTI_LANGUAGE"
+
       - name: Install scriv
         run: pip install "scriv[toml]"
 
       - name: Check for changelog fragments
         run: |
+          PYTHON_ROOT="${{ steps.python_layout.outputs.root }}"
+          if [ "$PYTHON_ROOT" = "." ]; then
+            FRAGMENT_DIR="changelog.d"
+            SOURCE_PATTERN="^(src/|tests/|scripts/)"
+          else
+            FRAGMENT_DIR="$PYTHON_ROOT/changelog.d"
+            SOURCE_PATTERN="^$PYTHON_ROOT/(src/|tests/|scripts/)"
+          fi
+
           # Get list of fragment files (excluding README and template)
-          FRAGMENTS=$(find changelog.d -name "*.md" ! -name "README.md" ! -name "*.j2" 2>/dev/null | wc -l)
+          FRAGMENTS=$(find "$FRAGMENT_DIR" -name "*.md" ! -name "README.md" ! -name "*.j2" 2>/dev/null | wc -l)
 
           # Get changed files in PR
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
 
           # Check if any source files changed (excluding docs and config)
-          SOURCE_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^(src/|tests/|scripts/)" | wc -l)
+          SOURCE_CHANGED=$(echo "$CHANGED_FILES" | grep -E "$SOURCE_PATTERN" | wc -l)
 
           if [ "$SOURCE_CHANGED" -gt 0 ] && [ "$FRAGMENTS" -eq 0 ]; then
             echo "::warning::No changelog fragment found. Please run 'scriv create' and document your changes."
@@ -259,6 +409,31 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Detect Python layout
+        id: python_layout
+        run: |
+          if [ -f pyproject.toml ]; then
+            PYTHON_ROOT="."
+            MULTI_LANGUAGE="false"
+            echo "root=." >> "$GITHUB_OUTPUT"
+            echo "multi_language=false" >> "$GITHUB_OUTPUT"
+          elif [ -f python/pyproject.toml ]; then
+            PYTHON_ROOT="python"
+            MULTI_LANGUAGE="true"
+            echo "root=python" >> "$GITHUB_OUTPUT"
+            echo "multi_language=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not find pyproject.toml at repo root or python/pyproject.toml"
+            exit 1
+          fi
+
+          if [ "$PYTHON_ROOT" = "." ]; then
+            echo "dist_dir=dist" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_dir=$PYTHON_ROOT/dist" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected Python layout: root=$PYTHON_ROOT, multi_language=$MULTI_LANGUAGE"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -267,16 +442,26 @@ jobs:
       - name: Check if version changed
         id: version_check
         run: |
+          PYTHON_ROOT="${{ steps.python_layout.outputs.root }}"
+          PYPROJECT="$PYTHON_ROOT/pyproject.toml"
+
           # Get current version from pyproject.toml
-          CURRENT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)
+          CURRENT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' "$PYPROJECT")
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
+          if [ "${{ steps.python_layout.outputs.multi_language }}" = "true" ]; then
+            TAG="py_v$CURRENT_VERSION"
+          else
+            TAG="v$CURRENT_VERSION"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
           # Check if tag exists
-          if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
-            echo "Tag v$CURRENT_VERSION already exists, skipping release"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping release"
             echo "should_release=false" >> $GITHUB_OUTPUT
           else
-            echo "New version detected: $CURRENT_VERSION"
+            echo "New version detected: $CURRENT_VERSION ($TAG)"
             echo "should_release=true" >> $GITHUB_OUTPUT
           fi
 
@@ -296,9 +481,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python scripts/create_github_release.py \
+          python "${{ steps.python_layout.outputs.root }}/scripts/create_github_release.py" \
             --version "${{ steps.version_check.outputs.current_version }}" \
-            --repository "${{ github.repository }}"
+            --repository "${{ github.repository }}" \
+            --repository-root "."
 
   # Manual release via workflow_dispatch - only after CI passes
   manual-release:
@@ -329,8 +515,34 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Detect Python layout
+        id: python_layout
+        run: |
+          if [ -f pyproject.toml ]; then
+            PYTHON_ROOT="."
+            MULTI_LANGUAGE="false"
+            echo "root=." >> "$GITHUB_OUTPUT"
+            echo "multi_language=false" >> "$GITHUB_OUTPUT"
+          elif [ -f python/pyproject.toml ]; then
+            PYTHON_ROOT="python"
+            MULTI_LANGUAGE="true"
+            echo "root=python" >> "$GITHUB_OUTPUT"
+            echo "multi_language=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not find pyproject.toml at repo root or python/pyproject.toml"
+            exit 1
+          fi
+
+          if [ "$PYTHON_ROOT" = "." ]; then
+            echo "dist_dir=dist" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_dir=$PYTHON_ROOT/dist" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected Python layout: root=$PYTHON_ROOT, multi_language=$MULTI_LANGUAGE"
+
       - name: Install dependencies
         run: |
+          cd "${{ steps.python_layout.outputs.root }}"
           python -m pip install --upgrade pip
           pip install build twine "scriv[toml]"
 
@@ -341,6 +553,7 @@ jobs:
 
       - name: Collect changelog fragments
         run: |
+          cd "${{ steps.python_layout.outputs.root }}"
           # Check if there are any fragments to collect
           FRAGMENTS=$(find changelog.d -name "*.md" ! -name "README.md" ! -name "*.j2" 2>/dev/null | wc -l)
           if [ "$FRAGMENTS" -gt 0 ]; then
@@ -353,27 +566,35 @@ jobs:
       - name: Version and commit
         id: version
         run: |
+          cd "${{ steps.python_layout.outputs.root }}"
           python scripts/version_and_commit.py \
             --bump-type "${{ github.event.inputs.bump_type }}" \
             --description "${{ github.event.inputs.description }}"
 
       - name: Build package
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
-        run: python -m build
+        run: |
+          cd "${{ steps.python_layout.outputs.root }}"
+          python -m build
 
       - name: Check package
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
-        run: twine check dist/*
+        run: |
+          cd "${{ steps.python_layout.outputs.root }}"
+          twine check dist/*
 
       - name: Publish to PyPI
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ${{ steps.python_layout.outputs.dist_dir }}
 
       - name: Create GitHub Release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python scripts/create_github_release.py \
+          python "${{ steps.python_layout.outputs.root }}/scripts/create_github_release.py" \
             --version "${{ steps.version.outputs.new_version }}" \
-            --repository "${{ github.repository }}"
+            --repository "${{ github.repository }}" \
+            --repository-root "."

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T10:33:28.054Z for PR creation at branch issue-21-b2b96320bbb6 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/21

--- a/changelog.d/20260614_issue_21_python_monorepo_releases.md
+++ b/changelog.d/20260614_issue_21_python_monorepo_releases.md
@@ -1,0 +1,3 @@
+### Added
+
+- Support Python releases from single-language repositories and multi-language monorepos by auto-detecting `pyproject.toml` at the repository root or under `python/`, namespacing multi-language tags as `py_v<version>`, using `[Python] <version>` multi-language release titles, and adding a PyPI badge linked to the exact published version page.

--- a/scripts/create_github_release.py
+++ b/scripts/create_github_release.py
@@ -3,12 +3,10 @@
 Create a GitHub release from CHANGELOG.md content.
 
 Usage:
-    python scripts/create_github_release.py --version VERSION --repository REPO \
-        [--tag-prefix PREFIX] [--language LANGUAGE]
+    python scripts/create_github_release.py --version VERSION --repository REPO
 
 Example:
-    python scripts/create_github_release.py --version 1.2.3 --repository owner/repo \
-        --tag-prefix python_v --language Python
+    python scripts/create_github_release.py --version 1.2.3 --repository owner/repo
 
 Environment variables:
     GH_TOKEN or GITHUB_TOKEN: GitHub token for authentication
@@ -20,6 +18,20 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from release_naming import (  # noqa: E402
+    PYPROJECT_FILE,
+    PythonLayout,
+    build_pypi_badge,
+    build_release_tag,
+    build_release_title,
+    detect_python_layout,
+    normalize_version,
+)
 
 
 MAX_RELEASE_NOTES_BYTES = 60_000
@@ -77,12 +89,16 @@ def extract_changelog_entry(changelog_path: Path, version: str) -> str:
     return entry if entry else f"Release {version}"
 
 
-def append_pypi_badge_if_missing(release_notes: str, version: str) -> str:
-    """Append a PyPI version badge unless a shields.io badge is already present."""
+def append_pypi_badge_if_missing(
+    release_notes: str,
+    distribution_name: str,
+    version: str,
+) -> str:
+    """Append a linked PyPI version badge unless a shields.io badge exists."""
     if "img.shields.io" in release_notes.lower():
         return release_notes
 
-    badge = f"![PyPI](https://img.shields.io/badge/pypi-{version}-blue.svg)"
+    badge = build_pypi_badge(distribution_name, version)
     return f"{release_notes.rstrip()}\n\n{badge}"
 
 
@@ -138,12 +154,12 @@ def create_release(
     repository: str,
     release_notes: str,
     prerelease: bool = False,
-    tag_prefix: str = "v",
-    language: str = "Python",
+    distribution_name: str = "my-package",
+    multi_language: bool = False,
 ) -> None:
     """Create a GitHub release using gh CLI."""
-    tag = f"{tag_prefix}{version}"
-    title = f"[{language}] {version}"
+    tag = build_release_tag(version, multi_language)
+    title = build_release_title(version, distribution_name, multi_language)
     original_notes_size = release_notes_size(release_notes)
     release_notes = cap_release_notes(release_notes, repository, tag)
     capped_notes_size = release_notes_size(release_notes)
@@ -179,6 +195,31 @@ def create_release(
     print(f"\n✅ GitHub release {tag} created successfully!")
 
 
+def get_pyproject_value(pyproject_path: Path, key: str) -> str:
+    """Extract a top-level string value from pyproject.toml."""
+    content = pyproject_path.read_text(encoding=ENCODING)
+    match = re.search(
+        rf"^{re.escape(key)}\s*=\s*[\"']([^\"']+)[\"']",
+        content,
+        re.MULTILINE,
+    )
+    if not match:
+        msg = f"Could not find {key!r} in {pyproject_path}"
+        raise ValueError(msg)
+    return match.group(1)
+
+
+def resolve_python_layout(repository_root: Path) -> PythonLayout:
+    """Detect layout from the repository root, falling back to this script's root."""
+    try:
+        return detect_python_layout(repository_root)
+    except FileNotFoundError:
+        script_root = SCRIPT_DIR.parent
+        if (script_root / PYPROJECT_FILE).is_file():
+            return PythonLayout(root=script_root, multi_language=False)
+        raise
+
+
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -202,14 +243,9 @@ def main() -> int:
         help="Mark as prerelease",
     )
     parser.add_argument(
-        "--tag-prefix",
-        default="v",
-        help='Tag prefix for the release (default "v")',
-    )
-    parser.add_argument(
-        "--language",
-        default="Python",
-        help='Language label for the release title (default "Python")',
+        "--repository-root",
+        default=".",
+        help="Repository root used for Python layout auto-detection",
     )
 
     args = parser.parse_args()
@@ -231,22 +267,29 @@ def main() -> int:
         )
         return 1
 
-    # Determine project root
-    script_dir = Path(__file__).parent
-    project_root = script_dir.parent
+    # Determine Python project root and package metadata.
+    layout = resolve_python_layout(Path(args.repository_root))
+    project_root = layout.root
+    pyproject_path = project_root / PYPROJECT_FILE
     changelog_path = project_root / "CHANGELOG.md"
 
     try:
-        release_notes = extract_changelog_entry(changelog_path, args.version)
-        release_notes = append_pypi_badge_if_missing(release_notes, args.version)
+        bare_version = normalize_version(args.version)
+        distribution_name = get_pyproject_value(pyproject_path, "name")
+        release_notes = extract_changelog_entry(changelog_path, bare_version)
+        release_notes = append_pypi_badge_if_missing(
+            release_notes,
+            distribution_name,
+            bare_version,
+        )
 
         create_release(
-            args.version,
+            bare_version,
             args.repository,
             release_notes,
             args.prerelease,
-            args.tag_prefix,
-            args.language,
+            distribution_name,
+            layout.multi_language,
         )
 
         return 0

--- a/scripts/detect_code_changes.py
+++ b/scripts/detect_code_changes.py
@@ -123,7 +123,16 @@ def is_excluded_from_code_changes(file_path: str) -> bool:
         return True
 
     # Exclude specific folders from code changes
-    excluded_folders = ["changelog.d/", "docs/", "experiments/", "examples/"]
+    excluded_folders = [
+        "changelog.d/",
+        "docs/",
+        "experiments/",
+        "examples/",
+        "python/changelog.d/",
+        "python/docs/",
+        "python/experiments/",
+        "python/examples/",
+    ]
 
     for folder in excluded_folders:
         if file_path.startswith(folder):
@@ -151,11 +160,15 @@ def detect_changes() -> None:
     set_output("py-changed", "true" if py_changed else "false")
 
     # Detect tests/ changes
-    tests_changed = any(f.startswith("tests/") for f in changed_files)
+    tests_changed = any(
+        f.startswith("tests/") or f.startswith("python/tests/") for f in changed_files
+    )
     set_output("tests-changed", "true" if tests_changed else "false")
 
     # Detect pyproject.toml changes
-    package_changed = "pyproject.toml" in changed_files
+    package_changed = any(
+        f in {"pyproject.toml", "python/pyproject.toml"} for f in changed_files
+    )
     set_output("package-changed", "true" if package_changed else "false")
 
     # Detect documentation changes (any .md file)

--- a/scripts/format_release_notes.py
+++ b/scripts/format_release_notes.py
@@ -23,7 +23,19 @@ import argparse
 import re
 import subprocess
 import sys
+from pathlib import Path
 from typing import Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from release_naming import (  # noqa: E402
+    PYPROJECT_FILE,
+    build_pypi_badge,
+    detect_python_layout,
+    normalize_version,
+)
 
 
 def run_gh_command(args: list[str]) -> tuple[bool, str]:
@@ -90,10 +102,7 @@ def format_release_body(
     formatted_parts = []
 
     # Add PyPI badge
-    pypi_badge = (
-        f"[![PyPI version](https://img.shields.io/pypi/v/{package_name}.svg)]"
-        f"(https://pypi.org/project/{package_name}/)"
-    )
+    pypi_badge = build_pypi_badge(package_name, version)
     formatted_parts.append(pypi_badge)
     formatted_parts.append("")
 
@@ -112,7 +121,8 @@ def format_release_body(
     cleaned_body = cleaned_body.replace('\\"', '"')
 
     # Remove duplicate version headers if present
-    version_pattern = rf"^#+\s*v?{re.escape(version)}\s*$"
+    bare_version = normalize_version(version)
+    version_pattern = rf"^#+\s*v?{re.escape(bare_version)}\s*$"
     cleaned_body = re.sub(version_pattern, "", cleaned_body, flags=re.MULTILINE)
 
     # Clean up excessive whitespace
@@ -149,11 +159,12 @@ def update_release(repository: str, release_id: str, new_body: str) -> bool:
 def get_package_name() -> str:
     """Get the package name from pyproject.toml."""
     try:
-        with open("pyproject.toml") as f:
-            content = f.read()
-            match = re.search(r'^name\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
-            if match:
-                return match.group(1)
+        layout = detect_python_layout()
+        pyproject_path = layout.root / PYPROJECT_FILE
+        content = pyproject_path.read_text(encoding="utf-8")
+        match = re.search(r'^name\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+        if match:
+            return match.group(1)
     except FileNotFoundError:
         pass
 

--- a/scripts/release_naming.py
+++ b/scripts/release_naming.py
@@ -1,0 +1,88 @@
+"""Layout-aware release naming helpers for the Python package."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
+from urllib.parse import quote
+
+
+LANGUAGE = "Python"
+MULTI_LANGUAGE_TAG_PREFIX = "py_v"
+SINGLE_LANGUAGE_TAG_PREFIX = "v"
+PYPROJECT_FILE = "pyproject.toml"
+PYTHON_SUBDIRECTORY = "python"
+
+
+@dataclass(frozen=True)
+class PythonLayout:
+    """Detected Python package layout inside a repository."""
+
+    root: Path
+    multi_language: bool
+
+
+def detect_python_layout(
+    repository_root: Optional[Union[str, Path]] = None,
+) -> PythonLayout:
+    """Detect whether Python files live at the repo root or under python/."""
+    root = Path.cwd() if repository_root is None else Path(repository_root)
+
+    if (root / PYPROJECT_FILE).is_file():
+        return PythonLayout(root=root, multi_language=False)
+
+    python_root = root / PYTHON_SUBDIRECTORY
+    if (python_root / PYPROJECT_FILE).is_file():
+        return PythonLayout(root=python_root, multi_language=True)
+
+    msg = (
+        f"Could not find {PYPROJECT_FILE} at {root / PYPROJECT_FILE} "
+        f"or {python_root / PYPROJECT_FILE}"
+    )
+    raise FileNotFoundError(msg)
+
+
+def normalize_version(version: str) -> str:
+    """Strip leading tag prefixes such as v, py_v, py-v, js_v, or rust_v."""
+    if not version:
+        return ""
+
+    normalized = re.sub(r"^[A-Za-z]+[-_]v?", "", str(version).strip(), count=1)
+    return re.sub(r"^v", "", normalized, count=1)
+
+
+def get_tag_prefix(multi_language: bool) -> str:
+    """Return the release tag prefix for the detected layout."""
+    if multi_language:
+        return MULTI_LANGUAGE_TAG_PREFIX
+    return SINGLE_LANGUAGE_TAG_PREFIX
+
+
+def build_release_tag(version: str, multi_language: bool) -> str:
+    """Build an idempotent release tag for the detected layout."""
+    return f"{get_tag_prefix(multi_language)}{normalize_version(version)}"
+
+
+def build_release_title(
+    version: str,
+    distribution_name: str,
+    multi_language: bool,
+) -> str:
+    """Build the GitHub release title for the detected layout."""
+    bare_version = normalize_version(version)
+    if multi_language:
+        return f"[{LANGUAGE}] {bare_version}"
+    return f"{distribution_name} {bare_version}"
+
+
+def build_pypi_badge(distribution_name: str, version: str) -> str:
+    """Build a shields.io PyPI badge linked to the exact version page."""
+    bare_version = normalize_version(version)
+    badge_version = quote(bare_version, safe="")
+    package_path = quote(distribution_name, safe="")
+    version_path = quote(bare_version, safe="")
+    image_url = f"https://img.shields.io/badge/pypi-{badge_version}-blue.svg?logo=pypi"
+    package_url = f"https://pypi.org/project/{package_path}/{version_path}/"
+    return f"[![PyPI version]({image_url})]({package_url})"

--- a/scripts/version_and_commit.py
+++ b/scripts/version_and_commit.py
@@ -75,6 +75,15 @@ def get_current_version(pyproject_path: Path) -> str:
     return match.group(1)
 
 
+def get_repo_root() -> Path:
+    """Return the current git repository root."""
+    output = run_command(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture=True,
+    ).stdout.strip()
+    return Path(output)
+
+
 def configure_git() -> None:
     """Configure git for automated commits."""
     print("Configuring git...")
@@ -86,7 +95,10 @@ def configure_git() -> None:
     )
 
 
-def check_remote_changes(pyproject_path: Path) -> tuple[bool, str]:
+def check_remote_changes(
+    pyproject_path: Path,
+    pyproject_git_path: str,
+) -> tuple[bool, str]:
     """
     Check if remote main has advanced (handles re-runs).
     Returns (already_released, remote_version).
@@ -111,7 +123,7 @@ def check_remote_changes(pyproject_path: Path) -> tuple[bool, str]:
 
         # Get remote version
         remote_content = run_command(
-            ["git", "show", "origin/main:pyproject.toml"],
+            ["git", "show", f"origin/main:{pyproject_git_path}"],
             capture=True,
         ).stdout
 
@@ -157,9 +169,11 @@ def main() -> int:
     args = parser.parse_args()
 
     # Determine project root
-    script_dir = Path(__file__).parent
+    script_dir = Path(__file__).resolve().parent
     project_root = script_dir.parent
     pyproject_path = project_root / "pyproject.toml"
+    repo_root = get_repo_root()
+    pyproject_git_path = pyproject_path.relative_to(repo_root).as_posix()
 
     if not pyproject_path.exists():
         print(f"Error: {pyproject_path} not found", file=sys.stderr)
@@ -170,7 +184,10 @@ def main() -> int:
         configure_git()
 
         # Check for remote changes
-        already_released, remote_version = check_remote_changes(pyproject_path)
+        already_released, remote_version = check_remote_changes(
+            pyproject_path,
+            pyproject_git_path,
+        )
 
         if already_released:
             print("Version bump already completed in previous run")
@@ -187,7 +204,7 @@ def main() -> int:
         print(f"\nBumping version ({args.bump_type})...")
         bump_cmd = [
             sys.executable,
-            "scripts/bump_version.py",
+            str(project_root / "scripts" / "bump_version.py"),
             args.bump_type,
         ]
         if args.description:

--- a/tests/test_create_github_release.py
+++ b/tests/test_create_github_release.py
@@ -17,8 +17,79 @@ sys.modules[spec.name] = module
 spec.loader.exec_module(module)  # type: ignore[union-attr]
 
 
-def test_create_release_uses_tag_prefix_and_language_title(monkeypatch) -> None:
-    """Release creation should separate tag format from display title."""
+def test_detect_python_layout_treats_root_manifest_as_single_language(tmp_path) -> None:
+    """A root pyproject.toml means the Python package owns the repository."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "my-package"\nversion = "1.2.3"\n',
+        encoding="utf-8",
+    )
+
+    layout = module.detect_python_layout(tmp_path)
+
+    assert layout.root == tmp_path
+    assert layout.multi_language is False
+
+
+def test_detect_python_layout_treats_python_subdir_as_multi_language(tmp_path) -> None:
+    """A python/pyproject.toml means releases share a multi-language namespace."""
+    python_root = tmp_path / "python"
+    python_root.mkdir()
+    (python_root / "pyproject.toml").write_text(
+        '[project]\nname = "my-package"\nversion = "1.2.3"\n',
+        encoding="utf-8",
+    )
+
+    layout = module.detect_python_layout(tmp_path)
+
+    assert layout.root == python_root
+    assert layout.multi_language is True
+
+
+def test_release_naming_uses_py_namespace_for_multi_language_layout() -> None:
+    """Multi-language Python releases should use a namespaced tag and title."""
+    assert module.build_release_tag("1.2.3", multi_language=True) == "py_v1.2.3"
+    assert (
+        module.build_release_title(
+            "1.2.3",
+            distribution_name="my-package",
+            multi_language=True,
+        )
+        == "[Python] 1.2.3"
+    )
+
+
+def test_release_naming_keeps_plain_tag_and_package_title_for_single_language() -> None:
+    """Single-language Python releases should keep the historical convention."""
+    assert module.build_release_tag("1.2.3", multi_language=False) == "v1.2.3"
+    assert (
+        module.build_release_title(
+            "1.2.3",
+            distribution_name="my-package",
+            multi_language=False,
+        )
+        == "my-package 1.2.3"
+    )
+
+
+def test_release_naming_is_idempotent_for_prefixed_versions() -> None:
+    """Re-running on a prefixed version must not double-prefix tags or titles."""
+    assert module.build_release_tag("py_v1.2.3", multi_language=True) == "py_v1.2.3"
+    assert module.build_release_tag("py-v1.2.3", multi_language=True) == "py_v1.2.3"
+    assert module.build_release_tag("v1.2.3", multi_language=False) == "v1.2.3"
+    assert module.normalize_version("rust_v0.2.0") == "0.2.0"
+
+
+def test_build_pypi_badge_links_to_exact_version_page() -> None:
+    """PyPI badge should point at the exact published version, not the project."""
+    badge = module.build_pypi_badge("my-package", "py_v1.2.3")
+
+    assert "img.shields.io" in badge
+    assert "https://pypi.org/project/my-package/1.2.3/" in badge
+    assert "py_v1.2.3" not in badge
+
+
+def test_create_release_uses_layout_aware_tag_and_title(monkeypatch) -> None:
+    """Release creation should derive tag and title from the detected layout."""
     commands = []
 
     def fake_run_command(cmd, check=True):
@@ -32,8 +103,8 @@ def test_create_release_uses_tag_prefix_and_language_title(monkeypatch) -> None:
         repository="owner/repo",
         release_notes="Release notes",
         prerelease=False,
-        tag_prefix="python_v",
-        language="Python",
+        distribution_name="my-package",
+        multi_language=True,
     )
 
     assert commands == [
@@ -41,7 +112,7 @@ def test_create_release_uses_tag_prefix_and_language_title(monkeypatch) -> None:
             "gh",
             "release",
             "create",
-            "python_v1.2.3",
+            "py_v1.2.3",
             "--repo",
             "owner/repo",
             "--title",
@@ -72,8 +143,8 @@ def test_create_release_caps_oversized_release_notes(monkeypatch) -> None:
         repository="owner/repo",
         release_notes=oversized_notes,
         prerelease=False,
-        tag_prefix="python_v",
-        language="Python",
+        distribution_name="my-package",
+        multi_language=True,
     )
 
     release_notes = commands[0][commands[0].index("--notes") + 1]
@@ -82,23 +153,26 @@ def test_create_release_caps_oversized_release_notes(monkeypatch) -> None:
     assert release_notes.startswith("Important release summary")
     assert "Tail marker that should be omitted" not in release_notes
     assert "Release notes were truncated" in release_notes
-    assert (
-        "https://github.com/owner/repo/blob/python_v1.2.3/CHANGELOG.md" in release_notes
-    )
+    assert "https://github.com/owner/repo/blob/py_v1.2.3/CHANGELOG.md" in release_notes
 
 
-def test_append_pypi_badge_if_missing_adds_static_version_badge() -> None:
-    """Release notes should get a PyPI badge before gh creates the release."""
-    body = module.append_pypi_badge_if_missing("Release notes", "1.2.3")
+def test_append_pypi_badge_if_missing_adds_linked_version_badge() -> None:
+    """Release notes should get a linked PyPI badge before gh creates the release."""
+    body = module.append_pypi_badge_if_missing("Release notes", "my-package", "1.2.3")
 
     assert "Release notes" in body
-    assert "https://img.shields.io/badge/pypi-1.2.3-blue.svg" in body
+    assert "https://img.shields.io" in body
+    assert "https://pypi.org/project/my-package/1.2.3/" in body
 
 
 def test_append_pypi_badge_if_missing_does_not_duplicate_badge() -> None:
     """Existing shields.io badges should be preserved without duplication."""
     existing = (
-        "Release notes\n\n![PyPI](https://img.shields.io/badge/pypi-1.2.3-blue.svg)"
+        "Release notes\n\n"
+        "[![PyPI](https://img.shields.io/badge/pypi-1.2.3-blue.svg)]"
+        "(https://pypi.org/project/my-package/1.2.3/)"
     )
 
-    assert module.append_pypi_badge_if_missing(existing, "1.2.3") == existing
+    assert (
+        module.append_pypi_badge_if_missing(existing, "my-package", "1.2.3") == existing
+    )

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -80,6 +80,39 @@ def test_release_workflow_action_versions_are_current() -> None:
     assert_action_pin_count(release_workflow, "actions/download-artifact", "v7", 1)
 
 
+def test_release_workflow_auto_detects_python_layout() -> None:
+    """Release workflow should support root and python/ package layouts."""
+    workflow = read_workflow("release.yml")
+
+    assert "if [ -f pyproject.toml ]; then" in workflow
+    assert "elif [ -f python/pyproject.toml ]; then" in workflow
+    assert "root=python" in workflow
+    assert "multi_language=true" in workflow
+
+
+def test_release_workflow_namespaces_multi_language_python_tags() -> None:
+    """Multi-language releases should use py_v tags and plain root releases keep v."""
+    workflow = read_workflow("release.yml")
+    auto_release = workflow_job_block(workflow, "auto-release")
+
+    assert 'TAG="py_v$CURRENT_VERSION"' in auto_release
+    assert 'TAG="v$CURRENT_VERSION"' in auto_release
+    assert 'git rev-parse "$TAG"' in auto_release
+
+
+def test_release_workflow_runs_python_steps_from_detected_root() -> None:
+    """Package build and release commands should run against the detected root."""
+    workflow = read_workflow("release.yml")
+
+    assert 'cd "${{ steps.python_layout.outputs.root }}"' in workflow
+    assert "path: ${{ steps.python_layout.outputs.dist_dir }}" in workflow
+    assert "packages-dir: ${{ steps.python_layout.outputs.dist_dir }}" in workflow
+    assert (
+        'python "${{ steps.python_layout.outputs.root }}/scripts/create_github_release.py"'
+        in workflow
+    )
+
+
 STATUS_CHECK_FUNCTIONS = ("always()", "!cancelled()", "!failure()", "success()")
 
 


### PR DESCRIPTION
Fixes #21.

## Summary

- Auto-detect Python package layout from the release workflow: root `pyproject.toml` keeps single-language behavior, while `python/pyproject.toml` switches to multi-language behavior.
- Add a tested release-naming helper for idempotent version normalization, `py_v<version>` multi-language tags, plain `v<version>` single-language tags, `[Python] <version>` multi-language titles, and `<distribution> <version>` single-language titles.
- Add linked PyPI shields badges in release notes that point to the exact published version page: `https://pypi.org/project/<dist>/<version>/`.
- Run lint/test/build/changelog/manual-release steps from the detected Python root and keep change detection aware of `python/` layouts.

## Reproduction and Verification

The previous behavior was covered by new regression tests: root-only workflow assumptions, `python_v`/static badge expectations, and non-idempotent prefixed versions now fail without the helper/workflow changes.

Local checks run:

```bash
pytest
ruff check .
ruff format --check .
mypy src/
python scripts/check_file_size.py
python -m compileall scripts
python -m build
twine check dist/*
```

Notes:

- `mypy src/` passes, while the installed mypy version prints existing config warnings about `python_version = 3.9` and `strict_concatenate`.
- `python -m build` and `twine check dist/*` passed locally; generated `dist/` artifacts were removed before commit.
