### PR TITLE
Add warning annotations to Python file-size check

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-14T10:33:28.054Z for PR creation at branch issue-21-b2b96320bbb6 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/21
-# Updated: 2026-06-28T19:10:43.624Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-14T10:33:28.054Z for PR creation at branch issue-21-b2b96320bbb6 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/21
+# Updated: 2026-06-28T19:10:43.624Z

--- a/changelog.d/20260628_issue_24_file_size_warnings.md
+++ b/changelog.d/20260628_issue_24_file_size_warnings.md
@@ -1,0 +1,4 @@
+### Added
+
+- The Python file-size check now reports non-failing warnings and GitHub Actions
+  annotations for files above 900 lines before the hard 1000-line limit.

--- a/scripts/check_file_size.py
+++ b/scripts/check_file_size.py
@@ -6,10 +6,13 @@ Exits with error code 1 if any files exceed the limit.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 import sys
 from pathlib import Path
 
 MAX_LINES = 1000
+WARN_LINES = 900
 FILE_EXTENSIONS = [".py"]
 EXCLUDE_PATTERNS = [
     "node_modules",
@@ -23,6 +26,30 @@ EXCLUDE_PATTERNS = [
     ".eggs",
     "*.egg-info",
 ]
+
+
+class LineStatus(Enum):
+    """Line-count classification for a checked file."""
+
+    OK = "ok"
+    WARNING = "warning"
+    VIOLATION = "violation"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A file-size warning or violation."""
+
+    file: Path
+    lines: int
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Collected warnings and violations from a file-size check."""
+
+    warnings: list[Finding]
+    violations: list[Finding]
 
 
 def should_exclude(path: Path, exclude_patterns: list[str]) -> bool:
@@ -55,7 +82,7 @@ def find_python_files(directory: Path, exclude_patterns: list[str]) -> list[Path
             continue
         if path.is_file() and path.suffix in FILE_EXTENSIONS:
             files.append(path)
-    return files
+    return sorted(files)
 
 
 def count_lines(file_path: Path) -> int:
@@ -70,31 +97,128 @@ def count_lines(file_path: Path) -> int:
     return len(file_path.read_text(encoding="utf-8").split("\n"))
 
 
+def classify_line_count(line_count: int) -> LineStatus:
+    """Classify a file by line count.
+
+    Args:
+        line_count: Number of lines in the file
+
+    Returns:
+        File-size status
+    """
+    if line_count > MAX_LINES:
+        return LineStatus.VIOLATION
+    if line_count > WARN_LINES:
+        return LineStatus.WARNING
+    return LineStatus.OK
+
+
+def check_directory(directory: Path) -> CheckResult:
+    """Check Python files under a directory for warning and hard limits.
+
+    Args:
+        directory: Directory to scan
+
+    Returns:
+        Collected warnings and violations
+    """
+    root = directory.resolve()
+    warnings = []
+    violations = []
+
+    files = find_python_files(root, EXCLUDE_PATTERNS)
+    for file in files:
+        line_count = count_lines(file)
+        finding = Finding(file=file.relative_to(root), lines=line_count)
+        status = classify_line_count(line_count)
+
+        if status == LineStatus.VIOLATION:
+            violations.append(finding)
+        elif status == LineStatus.WARNING:
+            warnings.append(finding)
+
+    return CheckResult(warnings=warnings, violations=violations)
+
+
+def escape_annotation_property(value: str) -> str:
+    """Escape a GitHub Actions annotation property value."""
+    return (
+        value.replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+        .replace(":", "%3A")
+        .replace(",", "%2C")
+    )
+
+
+def escape_annotation_message(value: str) -> str:
+    """Escape a GitHub Actions annotation message."""
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def warning_annotation(finding: Finding) -> str:
+    """Build a GitHub Actions warning annotation for a near-limit file."""
+    message = (
+        f"File has {finding.lines} lines (approaching limit of {MAX_LINES}). "
+        f"Consider extracting code to keep at or below {WARN_LINES} lines and "
+        "prevent concurrent PR merge limit violations."
+    )
+
+    return (
+        f"::warning file={escape_annotation_property(finding.file.as_posix())}::"
+        f"{escape_annotation_message(message)}"
+    )
+
+
+def print_warnings(warnings: list[Finding]) -> None:
+    """Print non-failing file-size warnings."""
+    if not warnings:
+        return
+
+    for warning in warnings:
+        print(warning_annotation(warning))
+        print(
+            f"WARNING: {warning.file} has {warning.lines} lines "
+            f"(approaching limit of {MAX_LINES}, warning threshold: {WARN_LINES})"
+        )
+
+    print()
+    print(f"The following files are approaching the {MAX_LINES} line limit:")
+    for warning in warnings:
+        print(f"  {warning.file}")
+    print(
+        "\nConsider extracting code to prevent concurrent PR merge limit violations.\n"
+    )
+
+
+def print_violations(violations: list[Finding]) -> None:
+    """Print hard-limit file-size violations."""
+    if not violations:
+        return
+
+    print("✗ Found files exceeding the line limit:\n")
+    for violation in violations:
+        print(f"  {violation.file}: {violation.lines} lines (exceeds {MAX_LINES})")
+    print(f"\nPlease refactor these files to be under {MAX_LINES} lines\n")
+
+
 def main() -> None:
     """Main function."""
     cwd = Path.cwd()
-    print(f"\nChecking Python files for maximum {MAX_LINES} lines...\n")
+    print(
+        f"\nChecking Python files for maximum {MAX_LINES} lines "
+        f"(warning above {WARN_LINES})...\n"
+    )
 
-    files = find_python_files(cwd, EXCLUDE_PATTERNS)
-    violations = []
+    result = check_directory(cwd)
+    print_warnings(result.warnings)
 
-    for file in files:
-        line_count = count_lines(file)
-        if line_count > MAX_LINES:
-            violations.append({"file": file.relative_to(cwd), "lines": line_count})
-
-    if not violations:
-        print("✓ All files are within the line limit\n")
+    if not result.violations:
+        print("✓ All files are within the hard line limit\n")
         sys.exit(0)
-    else:
-        print("✗ Found files exceeding the line limit:\n")
-        for violation in violations:
-            print(
-                f"  {violation['file']}: {violation['lines']} lines "
-                f"(exceeds {MAX_LINES})"
-            )
-        print(f"\nPlease refactor these files to be under {MAX_LINES} lines\n")
-        sys.exit(1)
+
+    print_violations(result.violations)
+    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_check_file_size.py
+++ b/tests/test_check_file_size.py
@@ -1,0 +1,109 @@
+"""Tests for scripts/check_file_size.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_file_size.py"
+spec = importlib.util.spec_from_file_location("check_file_size", SCRIPT_PATH)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)  # type: ignore[union-attr]
+
+
+def write_python_file_with_lines(path: Path, line_count: int) -> None:
+    """Write a Python file with exactly the requested line count."""
+    path.write_text(
+        "\n".join(f"# line {line}" for line in range(1, line_count + 1)),
+        encoding="utf-8",
+    )
+
+
+def test_classifies_warning_band_without_blocking() -> None:
+    """Files above WARN_LINES but at or below MAX_LINES should only warn."""
+    assert module.classify_line_count(module.WARN_LINES) == module.LineStatus.OK
+    assert (
+        module.classify_line_count(module.WARN_LINES + 1) == module.LineStatus.WARNING
+    )
+    assert module.classify_line_count(module.MAX_LINES) == module.LineStatus.WARNING
+
+
+def test_classifies_hard_limit_violations() -> None:
+    """Files above MAX_LINES should remain hard failures."""
+    assert (
+        module.classify_line_count(module.MAX_LINES + 1) == module.LineStatus.VIOLATION
+    )
+
+
+def test_check_directory_reports_warning_and_violation_separately(tmp_path) -> None:
+    """Near-limit files should not be mixed with hard-limit failures."""
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    write_python_file_with_lines(source_dir / "near_limit.py", module.WARN_LINES + 1)
+    write_python_file_with_lines(source_dir / "over_limit.py", module.MAX_LINES + 1)
+    write_python_file_with_lines(source_dir / "small.py", module.WARN_LINES)
+
+    result = module.check_directory(tmp_path)
+
+    assert result.warnings == [
+        module.Finding(file=Path("src/near_limit.py"), lines=module.WARN_LINES + 1)
+    ]
+    assert result.violations == [
+        module.Finding(file=Path("src/over_limit.py"), lines=module.MAX_LINES + 1)
+    ]
+
+
+def test_warning_annotation_uses_github_actions_format() -> None:
+    """Near-limit files should produce a GitHub Actions warning annotation."""
+    finding = module.Finding(
+        file=Path("src/near_limit.py"),
+        lines=module.WARN_LINES + 1,
+    )
+
+    assert module.warning_annotation(finding) == (
+        "::warning file=src/near_limit.py::File has 901 lines "
+        "(approaching limit of 1000). Consider extracting code to keep at or below "
+        "900 lines and prevent concurrent PR merge limit violations."
+    )
+
+
+def test_main_emits_warning_annotation_without_failing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Warning-only files should annotate but keep the script successful."""
+    write_python_file_with_lines(tmp_path / "near_limit.py", module.WARN_LINES + 1)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr()
+    assert "::warning file=near_limit.py::File has 901 lines" in output.out
+    assert "WARNING: near_limit.py has 901 lines" in output.out
+    assert output.err == ""
+
+
+def test_main_keeps_hard_limit_violations_failing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Files over MAX_LINES should still fail the script."""
+    write_python_file_with_lines(tmp_path / "over_limit.py", module.MAX_LINES + 1)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main()
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr()
+    assert "over_limit.py: 1001 lines (exceeds 1000)" in output.out
+    assert output.err == ""


### PR DESCRIPTION
## Summary

- Add a `WARN_LINES` threshold at 900 lines to the Python file-size check.
- Emit non-failing GitHub Actions `::warning` annotations for files above the warning threshold.
- Keep files above `MAX_LINES` as hard failures.
- Add regression tests for warning classification, annotation output, and failure behavior.
- Add a changelog fragment for the CI gate enhancement.

Fixes #24

## Reproduction

The new `tests/test_check_file_size.py` coverage was added before implementation and initially failed because the script had no warning threshold, warning result collection, or annotation formatter.

## Tests

- `ruff check .`
- `ruff format --check .`
- `mypy src` (passes; current mypy emits config deprecation/version warnings)
- `python scripts/check_file_size.py`
- `pytest` (41 passed)
