### PR TITLE
fix(ci): gate Codecov upload on token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [detect-changes]
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     # always() && !cancelled() lets this job evaluate even though detect-changes
     # is skipped for workflow_dispatch; without it, the skipped dependency would
     # propagate and skip test despite the workflow_dispatch condition below.
@@ -228,11 +230,18 @@ jobs:
           cd "${{ steps.python_layout.outputs.root }}"
           pytest tests/ -v --cov=src --cov-report=xml --cov-report=term
 
+      - name: Report skipped Codecov upload
+        if: env.CODECOV_TOKEN == ''
+        run: echo "::notice::Skipping Codecov upload because CODECOV_TOKEN is not configured"
+
       - name: Upload coverage to Codecov
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v4
         with:
-          file: ./coverage.xml
-          fail_ci_if_error: false
+          file: ${{ steps.python_layout.outputs.root }}/coverage.xml
+          token: ${{ env.CODECOV_TOKEN }}
+          disable_search: true
+          fail_ci_if_error: true
 
   # === BUILD PACKAGE ===
   # Build package - runs if lint and test pass, or were skipped (docs-only PR)

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T10:33:28.054Z for PR creation at branch issue-21-b2b96320bbb6 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/21
-# Updated: 2026-07-03T15:43:11.653Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-14T10:33:28.054Z for PR creation at branch issue-21-b2b96320bbb6 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/21
+# Updated: 2026-07-03T15:43:11.653Z

--- a/changelog.d/20260703_issue_27_codecov_token_gate.md
+++ b/changelog.d/20260703_issue_27_codecov_token_gate.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Gate the release workflow Codecov upload on `CODECOV_TOKEN`, report a skipped
+  upload explicitly, and fail CI when an attempted upload fails.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -30,6 +30,25 @@ def workflow_job_block(workflow: str, job_name: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def workflow_step_block(job_block: str, step_name: str) -> str:
+    """Return the YAML text block for one named workflow step."""
+    lines = job_block.splitlines()
+    start = next(
+        index
+        for index, line in enumerate(lines)
+        if line.strip() == f"- name: {step_name}"
+    )
+    end = next(
+        (
+            index
+            for index, line in enumerate(lines[start + 1 :], start + 1)
+            if re.match(r"^      - ", line)
+        ),
+        len(lines),
+    )
+    return "\n".join(lines[start:end])
+
+
 def assert_action_pin_count(
     workflow: str, action: str, version: str, count: int
 ) -> None:
@@ -78,6 +97,25 @@ def test_release_workflow_action_versions_are_current() -> None:
     assert_action_pin_count(release_workflow, "actions/checkout", "v6", 7)
     assert_action_pin_count(release_workflow, "actions/upload-artifact", "v7", 1)
     assert_action_pin_count(release_workflow, "actions/download-artifact", "v7", 1)
+
+
+def test_release_workflow_gates_codecov_upload_on_token() -> None:
+    """Codecov uploads should be skipped without a token and fail loudly with one."""
+    workflow = read_workflow("release.yml")
+    test_job = workflow_job_block(workflow, "test")
+    skip_step = workflow_step_block(test_job, "Report skipped Codecov upload")
+    upload_step = workflow_step_block(test_job, "Upload coverage to Codecov")
+
+    assert "CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}" in test_job
+    assert "if: env.CODECOV_TOKEN == ''" in skip_step
+    assert "::notice::" in skip_step
+    assert "if: env.CODECOV_TOKEN != ''" in upload_step
+    assert "uses: codecov/codecov-action@v4" in upload_step
+    assert "file: ${{ steps.python_layout.outputs.root }}/coverage.xml" in upload_step
+    assert "token: ${{ env.CODECOV_TOKEN }}" in upload_step
+    assert "disable_search: true" in upload_step
+    assert "fail_ci_if_error: true" in upload_step
+    assert "fail_ci_if_error: false" not in upload_step
 
 
 def test_release_workflow_auto_detects_python_layout() -> None:


### PR DESCRIPTION
## Summary

Fixes #27.

- Gates the release workflow Codecov upload on a configured CODECOV_TOKEN.
- Emits an explicit GitHub Actions notice when the token is missing instead of attempting a doomed tokenless upload.
- Makes attempted Codecov uploads fail CI with fail_ci_if_error: true and passes the detected Python-root coverage file path.
- Adds a workflow-policy regression test and changelog fragment.

## Reproduction

The new test first failed against the original workflow because the skipped-upload notice step was absent and Codecov still used fail_ci_if_error: false.

## Verification

- pytest tests/test_workflows.py::test_release_workflow_gates_codecov_upload_on_token -q
- ruff check .
- ruff format --check .
- mypy src
- python scripts/check_file_size.py
- pytest
- pytest tests/ -v --cov=src --cov-report=xml --cov-report=term