### PR TITLE
Suppress Git default-branch checkout warning in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  GIT_CONFIG_COUNT: '1'
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 jobs:
   # === DETECT CHANGES - determines which jobs should run ===
   detect-changes:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-03T16:50:10.358Z for PR creation at branch issue-28-26f79e95eb2c for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/28

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-03T16:50:10.358Z for PR creation at branch issue-28-26f79e95eb2c for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/28

--- a/changelog.d/20260703_issue_28_git_default_branch_env.md
+++ b/changelog.d/20260703_issue_28_git_default_branch_env.md
@@ -1,0 +1,2 @@
+### Fixed
+- Suppress Git's default-branch hint during release workflow checkout.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -99,6 +99,19 @@ def test_release_workflow_action_versions_are_current() -> None:
     assert_action_pin_count(release_workflow, "actions/download-artifact", "v7", 1)
 
 
+def test_release_workflow_sets_git_default_branch_before_checkout() -> None:
+    """Release workflow should suppress Git's default branch hint during checkout."""
+    workflow = read_workflow("release.yml")
+
+    assert "env:\n  GIT_CONFIG_COUNT: '1'" in workflow
+    assert "  GIT_CONFIG_KEY_0: init.defaultBranch" in workflow
+    assert "  GIT_CONFIG_VALUE_0: main" in workflow
+
+    env_index = workflow.index("env:\n  GIT_CONFIG_COUNT: '1'")
+    first_checkout_index = workflow.index("uses: actions/checkout@v6")
+    assert env_index < first_checkout_index
+
+
 def test_release_workflow_gates_codecov_upload_on_token() -> None:
     """Codecov uploads should be skipped without a token and fail loudly with one."""
     workflow = read_workflow("release.yml")


### PR DESCRIPTION
## Summary
- Add workflow-level `GIT_CONFIG_*` runtime config to `.github/workflows/release.yml` so `actions/checkout@v6` initializes with `init.defaultBranch=main`.
- Add a workflow contract test that requires the env block to be present before the first checkout action.
- Add a changelog fragment for the CI warning suppression.

Fixes #28

## Reproduction
1. Run the release workflow on a runner where Git emits the Git 3.0 default-branch hint during `git init`.
2. Inspect the `actions/checkout@v6` log before this change and observe the default initial branch warning.
3. The new contract test reproduces the missing workflow-level config by failing when the `GIT_CONFIG_*` env block is absent.

## Verification
- `.venv/bin/python -m pytest tests/test_workflows.py::test_release_workflow_sets_git_default_branch_before_checkout -q`
- `.venv/bin/python -m pytest`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mypy src/`
- `.venv/bin/python scripts/check_file_size.py`