### PR TITLE
Upgrade setup-python and Codecov actions for Node 24 runners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -195,7 +195,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -241,7 +241,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           file: ${{ steps.python_layout.outputs.root }}/coverage.xml
           token: ${{ env.CODECOV_TOKEN }}
@@ -269,7 +269,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -333,7 +333,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -419,7 +419,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -531,7 +531,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-22T20:56:44.754Z for PR creation at branch issue-32-9cb445fe7b8a for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/32

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-22T20:56:44.754Z for PR creation at branch issue-32-9cb445fe7b8a for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/32

--- a/changelog.d/20260722_issue_32_node24_actions.md
+++ b/changelog.d/20260722_issue_32_node24_actions.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Upgrade the Python setup and Codecov workflow actions to Node 24-compatible
+  major versions and guard those pins with workflow policy tests.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -95,8 +95,13 @@ def test_release_workflow_action_versions_are_current() -> None:
     release_workflow = read_workflow("release.yml")
 
     assert_action_pin_count(release_workflow, "actions/checkout", "v6", 7)
+    assert_action_pin_count(release_workflow, "actions/setup-python", "v6", 7)
     assert_action_pin_count(release_workflow, "actions/upload-artifact", "v7", 1)
     assert_action_pin_count(release_workflow, "actions/download-artifact", "v7", 1)
+    assert_action_pin_count(release_workflow, "codecov/codecov-action", "v7", 1)
+
+    assert_action_pin_absent(release_workflow, "actions/setup-python", "v5")
+    assert_action_pin_absent(release_workflow, "codecov/codecov-action", "v4")
 
 
 def test_release_workflow_sets_git_default_branch_before_checkout() -> None:
@@ -123,7 +128,7 @@ def test_release_workflow_gates_codecov_upload_on_token() -> None:
     assert "if: env.CODECOV_TOKEN == ''" in skip_step
     assert "::notice::" in skip_step
     assert "if: env.CODECOV_TOKEN != ''" in upload_step
-    assert "uses: codecov/codecov-action@v4" in upload_step
+    assert "uses: codecov/codecov-action@v7" in upload_step
     assert "file: ${{ steps.python_layout.outputs.root }}/coverage.xml" in upload_step
     assert "token: ${{ env.CODECOV_TOKEN }}" in upload_step
     assert "disable_search: true" in upload_step
@@ -231,12 +236,14 @@ def test_docs_workflow_action_versions_are_current() -> None:
     docs_workflow = read_workflow("docs.yml")
 
     assert_action_pin_count(docs_workflow, "actions/checkout", "v6", 1)
+    assert_action_pin_count(docs_workflow, "actions/setup-python", "v6", 1)
     assert_action_pin_count(docs_workflow, "actions/upload-artifact", "v7", 1)
     assert_action_pin_count(docs_workflow, "actions/configure-pages", "v6", 1)
     assert_action_pin_count(docs_workflow, "actions/upload-pages-artifact", "v5", 1)
     assert_action_pin_count(docs_workflow, "actions/deploy-pages", "v5", 1)
 
     assert_action_pin_absent(docs_workflow, "actions/checkout", "v4")
+    assert_action_pin_absent(docs_workflow, "actions/setup-python", "v5")
     assert_action_pin_absent(docs_workflow, "actions/upload-artifact", "v4")
     assert_action_pin_absent(docs_workflow, "actions/configure-pages", "v5")
     assert_action_pin_absent(docs_workflow, "actions/upload-pages-artifact", "v3")


### PR DESCRIPTION
## Summary

Fixes #32.

- Upgrade all eight `actions/setup-python` references from v5 to v6 across the release and docs workflows.
- Upgrade the gated Codecov upload from `codecov/codecov-action@v4` to v7.
- Add workflow policy assertions for the required current majors and explicitly reject the outdated majors.
- Add a changelog fragment and remove the autogenerated branch placeholder.

## Reproduction

Before the workflow updates, the new policy assertions fail in three places: the release workflow contains zero `setup-python@v6` references, the docs workflow contains zero `setup-python@v6` references, and the gated Codecov step still uses v4 instead of v7.

## Verification

- `.venv/bin/python -m pytest tests/test_workflows.py -q` (13 passed)
- `.venv/bin/python -m pytest --cov=src --cov-report=term` (44 passed, 100% package coverage)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mypy src/`
- `.venv/bin/python scripts/check_file_size.py`
- `.venv/bin/sphinx-build -W --keep-going -b html docs _site`
- `.venv/bin/python -m build`
- `.venv/bin/twine check dist/*`
- `git diff --check`

`mypy` passed with the repository's existing warnings about its Python 3.9 target and deprecated `strict_concatenate` setting.
