### PR TITLE
Restrict release workflow token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-22T21:12:19.999Z for PR creation at branch issue-33-42c5c4da9408 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/33

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-22T21:12:19.999Z for PR creation at branch issue-33-42c5c4da9408 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/33

--- a/changelog.d/20260722_issue_33_release_permissions.md
+++ b/changelog.d/20260722_issue_33_release_permissions.md
@@ -1,0 +1,4 @@
+### Security
+
+- Default the release workflow token to read-only repository access, with write
+  access limited to the publishing jobs that require it.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -71,6 +71,17 @@ def test_release_workflow_keeps_main_releases_running() -> None:
     assert "cancel-in-progress: true" not in workflow
 
 
+def test_release_workflow_uses_least_privilege_permissions() -> None:
+    """Only publishing jobs should receive write-capable tokens."""
+    workflow = read_workflow("release.yml")
+
+    assert "\npermissions:\n  contents: read\n" in workflow
+
+    for job_name in ("auto-release", "manual-release"):
+        block = workflow_job_block(workflow, job_name)
+        assert "permissions:\n      contents: write\n      id-token: write" in block
+
+
 def test_release_workflow_jobs_have_explicit_timeouts() -> None:
     """Release workflow jobs should fail fast instead of using the six-hour default."""
     workflow = read_workflow("release.yml")


### PR DESCRIPTION
## Summary

- default the release workflow's `GITHUB_TOKEN` to read-only repository contents
- preserve explicit `contents: write` and `id-token: write` grants only on the automatic and manual publishing jobs
- add a workflow-policy regression test and a Security changelog fragment

## Reproduction

Before this change, the workflow had no top-level permissions declaration:

```bash
grep -n '^permissions:' .github/workflows/release.yml
# no output
```

That caused non-publishing jobs to inherit the repository or organization default token scope.

## Verification

- `pytest tests/test_workflows.py -v`
- `pytest -v --cov=src --cov-report=term`
- `ruff check .`
- `ruff format --check .`
- `mypy src/`
- `python scripts/check_file_size.py`

Fixes #33