### PR TITLE
Fix Codecov v7 coverage file input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
         if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v7
         with:
-          file: ${{ steps.python_layout.outputs.root }}/coverage.xml
+          files: ${{ steps.python_layout.outputs.root }}/coverage.xml
           token: ${{ env.CODECOV_TOKEN }}
           disable_search: true
           fail_ci_if_error: true

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-22T21:18:12.571Z for PR creation at branch issue-34-0c62870eba13 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/34

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-22T21:18:12.571Z for PR creation at branch issue-34-0c62870eba13 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/34

--- a/changelog.d/20260722_issue_34_codecov_v7_input.md
+++ b/changelog.d/20260722_issue_34_codecov_v7_input.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Use the Codecov v7 `files` input so the generated coverage report is uploaded.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -140,7 +140,8 @@ def test_release_workflow_gates_codecov_upload_on_token() -> None:
     assert "::notice::" in skip_step
     assert "if: env.CODECOV_TOKEN != ''" in upload_step
     assert "uses: codecov/codecov-action@v7" in upload_step
-    assert "file: ${{ steps.python_layout.outputs.root }}/coverage.xml" in upload_step
+    assert "files: ${{ steps.python_layout.outputs.root }}/coverage.xml" in upload_step
+    assert "\n          file:" not in upload_step
     assert "token: ${{ env.CODECOV_TOKEN }}" in upload_step
     assert "disable_search: true" in upload_step
     assert "fail_ci_if_error: true" in upload_step


### PR DESCRIPTION
Fixes #34.

## Summary

- Keep the release workflow on `codecov/codecov-action@v7`.
- Complete the v4-to-v7 migration by renaming the deprecated singular `file` input to v7's `files` input.
- Strengthen the workflow regression test to require `files` and reject the legacy singular input.
- Add a changelog fragment and remove the autogenerated branch placeholder.

## Root cause and reproduction

The Codecov action tag had already been upgraded to v7 by #36, but its configuration still used the v4-era `file` input. The focused regression test reproduces the partial migration by failing with:

```text
assert "files: ${{ steps.python_layout.outputs.root }}/coverage.xml" in upload_step
```

This means a straight major-version bump could silently stop selecting the generated `coverage.xml` report.

## Verification

- `.venv/bin/python -m pytest tests/test_workflows.py::test_release_workflow_gates_codecov_upload_on_token -q`
- `.venv/bin/python -m pytest --cov=src --cov-report=term` (45 passed, 100% package coverage)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mypy src/`
- `.venv/bin/python scripts/check_file_size.py`
- `.venv/bin/pre-commit run check-yaml --files .github/workflows/release.yml`
- `git diff --check`

`mypy` passed with the repository's existing Python 3.9 support and `strict_concatenate` deprecation warnings.
