### PR TITLE
fix(ci): harden release inputs and serialize writes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,21 +24,24 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 env:
   GIT_CONFIG_COUNT: '1'
   GIT_CONFIG_KEY_0: init.defaultBranch
   GIT_CONFIG_VALUE_0: main
 
+# Concurrency is intentionally job-scoped. Superseded read-only jobs cancel
+# independently, including on main. Write-capable release jobs share one FIFO
+# queue so a publication that has started is never cancelled and subsequent
+# publications run one at a time.
 jobs:
   # === DETECT CHANGES - determines which jobs should run ===
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-detect-changes
+      cancel-in-progress: true
     if: github.event_name != 'workflow_dispatch'
     outputs:
       any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
@@ -95,6 +98,9 @@ jobs:
     name: Lint and Format Check
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-lint
+      cancel-in-progress: true
     needs: [detect-changes]
     # !cancelled() lets this job evaluate even though detect-changes is skipped
     # for workflow_dispatch while still propagating workflow cancellation.
@@ -179,6 +185,9 @@ jobs:
     name: Test (Python 3.13)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-test
+      cancel-in-progress: true
     needs: [detect-changes]
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -252,6 +261,9 @@ jobs:
     name: Build Package
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-build
+      cancel-in-progress: true
     needs: [detect-changes, lint, test]
     # Build change-bearing automatic events and all manually dispatched releases.
     if: |
@@ -322,6 +334,9 @@ jobs:
     name: Changelog Fragment Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-changelog
+      cancel-in-progress: true
     needs: [detect-changes]
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
     steps:
@@ -405,6 +420,9 @@ jobs:
     name: Docker Image Build Check
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-docker-build
+      cancel-in-progress: true
     needs: [detect-changes]
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
     steps:
@@ -441,6 +459,10 @@ jobs:
   auto-release:
     name: Auto Release
     needs: [lint, test, build]
+    concurrency:
+      group: ${{ github.workflow }}-main-write
+      cancel-in-progress: false
+      queue: max
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -544,6 +566,10 @@ jobs:
   manual-release:
     name: Manual Release
     needs: [lint, test, build]
+    concurrency:
+      group: ${{ github.workflow }}-main-write
+      cancel-in-progress: false
+      queue: max
     # !cancelled() prevents the skipped detect-changes dependency from propagating
     # through lint/test/build while still propagating workflow cancellation.
     # The explicit result checks ensure release only proceeds after CI passes.
@@ -606,24 +632,29 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Collect changelog fragments
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
         run: |
           cd "${{ steps.python_layout.outputs.root }}"
           # Check if there are any fragments to collect
           FRAGMENTS=$(find changelog.d -name "*.md" ! -name "README.md" ! -name "*.j2" 2>/dev/null | wc -l)
           if [ "$FRAGMENTS" -gt 0 ]; then
             echo "Found $FRAGMENTS changelog fragment(s), collecting..."
-            scriv collect --version "${{ github.event.inputs.bump_type }}"
+            scriv collect --version "$BUMP_TYPE"
           else
             echo "No changelog fragments found, skipping collection"
           fi
 
       - name: Version and commit
         id: version
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.bump_type }}
+          DESCRIPTION: ${{ github.event.inputs.description }}
         run: |
           cd "${{ steps.python_layout.outputs.root }}"
           python scripts/version_and_commit.py \
-            --bump-type "${{ github.event.inputs.bump_type }}" \
-            --description "${{ github.event.inputs.description }}"
+            --bump-type "$BUMP_TYPE" \
+            --description "$DESCRIPTION"
 
       - name: Build package
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-01T16:35:18.313Z for PR creation at branch issue-42-f2bc2c308972 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/42

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-01T16:35:18.313Z for PR creation at branch issue-42-f2bc2c308972 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/42

--- a/changelog.d/20260801_issue_42_workflow_hardening.md
+++ b/changelog.d/20260801_issue_42_workflow_hardening.md
@@ -1,0 +1,9 @@
+### Security
+
+- Prevent workflow-dispatch inputs from being interpolated directly into release
+  shell scripts.
+
+### Fixed
+
+- Cancel superseded read-only CI jobs independently while preserving queued
+  release jobs and running them one at a time.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -48,6 +48,33 @@ def workflow_step_block(job_block: str, step_name: str) -> str:
     return "\n".join(lines[start:end])
 
 
+def workflow_run_blocks(workflow: str) -> list[str]:
+    """Return every shell ``run:`` block from a workflow."""
+    lines = workflow.splitlines()
+    blocks: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        indentation = len(line) - len(line.lstrip())
+        if not line.lstrip().startswith("run:"):
+            index += 1
+            continue
+
+        block = [line]
+        index += 1
+        while index < len(lines):
+            next_line = lines[index]
+            next_indentation = len(next_line) - len(next_line.lstrip())
+            if next_line.strip() and next_indentation <= indentation:
+                break
+            block.append(next_line)
+            index += 1
+        blocks.append("\n".join(block))
+
+    return blocks
+
+
 def assert_action_pin_count(
     workflow: str, action: str, version: str, count: int
 ) -> None:
@@ -62,12 +89,53 @@ def assert_action_pin_absent(workflow: str, action: str, version: str) -> None:
     assert not re.search(pattern, workflow)
 
 
-def test_release_workflow_keeps_main_releases_running() -> None:
-    """Main release runs must not be cancelled by follow-up pushes."""
-    workflow = read_workflow("release.yml")
+def test_workflow_run_blocks_do_not_interpolate_untrusted_inputs() -> None:
+    """Contributor-controlled inputs must reach shell scripts through env vars."""
+    unsafe_expression = re.compile(
+        r"\$\{\{\s*(?:inputs\.|github\.event\.inputs\.|github\.head_ref)[^}]*\}\}"
+    )
 
-    assert "cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}" in workflow
-    assert "cancel-in-progress: true" not in workflow
+    for path in sorted(WORKFLOWS.glob("*.y*ml")):
+        workflow = path.read_text(encoding="utf-8")
+        for run_block in workflow_run_blocks(workflow):
+            assert not unsafe_expression.search(run_block), (
+                f"{path.name} interpolates an untrusted expression in a run block:\n"
+                f"{run_block}"
+            )
+
+
+def test_release_workflow_separates_check_and_write_concurrency() -> None:
+    """Checks cancel independently while release writes share a FIFO queue."""
+    workflow = read_workflow("release.yml")
+    workflow_header = workflow.split("\njobs:\n", maxsplit=1)[0]
+
+    assert "\nconcurrency:\n" not in workflow_header
+
+    for job_name in (
+        "detect-changes",
+        "lint",
+        "test",
+        "build",
+        "changelog",
+        "docker-build",
+    ):
+        block = workflow_job_block(workflow, job_name)
+        expected_group = (
+            "group: ${{ github.workflow }}-${{ github.ref }}-" f"{job_name}"
+        )
+        assert expected_group in block
+        assert "cancel-in-progress: true" in block
+
+    write_concurrency = "\n".join(
+        (
+            "    concurrency:",
+            "      group: ${{ github.workflow }}-main-write",
+            "      cancel-in-progress: false",
+            "      queue: max",
+        )
+    )
+    for job_name in ("auto-release", "manual-release"):
+        assert write_concurrency in workflow_job_block(workflow, job_name)
 
 
 def test_release_workflow_uses_least_privilege_permissions() -> None:


### PR DESCRIPTION
## Summary

- route every `workflow_dispatch` release input through step environment variables before shell use
- replace workflow-level concurrency with independent cancellable groups for read-only checks
- serialize both write-capable release jobs through one non-cancelling `main-write` FIFO queue
- add workflow-wide command-injection and release-concurrency regression coverage
- add a security/fix changelog fragment

## Reproduction

Before the workflow fix, the new focused tests fail in two places:

1. `test_workflow_run_blocks_do_not_interpolate_untrusted_inputs` finds `github.event.inputs.bump_type` in the changelog collection shell block (and the workflow also directly interpolates the free-form description in the version command). GitHub expands these expressions into the generated script before Bash parses it.
2. `test_release_workflow_separates_check_and_write_concurrency` finds top-level concurrency, which couples cancellable checks to non-cancellable publishers and prevents checks on `main` from superseding stale instances independently.

## Implementation

The changelog and version steps now pass dispatch inputs through `env` and consume quoted shell variables. `detect-changes`, `lint`, `test`, `build`, `changelog`, and `docker-build` each use a ref- and job-specific group with `cancel-in-progress: true`. `auto-release` and `manual-release` share `${{ github.workflow }}-main-write` with `cancel-in-progress: false` and `queue: max`, so an active publication completes and later writes execute one at a time.

## Verification

- `.venv/bin/python -m pytest -v --cov=src --cov-report=xml --cov-report=term` (62 passed, 100% package coverage)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mypy src`
- `.venv/bin/python scripts/check_file_size.py`
- tracked-file `secretlint` scan
- Ruby YAML parse of `.github/workflows/release.yml`
- `git diff --check origin/main...HEAD`

Fixes #42
