### PR TITLE
Fix changelog check injection and enforce fragments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,7 +378,11 @@ jobs:
         run: pip install "scriv[toml]"
 
       - name: Check for changelog fragments
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
         run: |
+          set -euo pipefail
+
           PYTHON_ROOT="${{ steps.python_layout.outputs.root }}"
           if [ "$PYTHON_ROOT" = "." ]; then
             FRAGMENT_DIR="changelog.d"
@@ -392,13 +396,13 @@ jobs:
           FRAGMENTS=$(find "$FRAGMENT_DIR" -name "*.md" ! -name "README.md" ! -name "*.j2" 2>/dev/null | wc -l)
 
           # Get changed files in PR
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CHANGED_FILES=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD")
 
           # Check if any source files changed (excluding docs and config)
-          SOURCE_CHANGED=$(echo "$CHANGED_FILES" | grep -E "$SOURCE_PATTERN" | wc -l)
+          SOURCE_CHANGED=$(printf '%s\n' "$CHANGED_FILES" | grep -cE "$SOURCE_PATTERN" || true)
 
           if [ "$SOURCE_CHANGED" -gt 0 ] && [ "$FRAGMENTS" -eq 0 ]; then
-            echo "::warning::No changelog fragment found. Please run 'scriv create' and document your changes."
+            echo "::error::No changelog fragment found. Please run 'scriv create' and document your changes."
             echo ""
             echo "To create a changelog fragment:"
             echo "  pip install 'scriv[toml]'"
@@ -406,9 +410,7 @@ jobs:
             echo ""
             echo "This is similar to adding a changeset in JavaScript projects."
             echo "See changelog.d/README.md for more information."
-            # Note: This is a warning, not a failure, to allow flexibility
-            # Change 'exit 0' to 'exit 1' to make it required
-            exit 0
+            exit 1
           fi
 
           echo "✓ Changelog check passed"

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-02T20:27:36.151Z for PR creation at branch issue-45-8c6b0f120bee for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/45

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-02T20:27:36.151Z for PR creation at branch issue-45-8c6b0f120bee for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/45

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ ls changelog.d/*.md
 The GitHub Actions workflow provides:
 
 1. **Linting**: Ruff linting, formatting, and mypy type checking
-2. **Changelog check**: Warns if PRs are missing changelog fragments
+2. **Changelog check**: Fails source-changing PRs that omit changelog fragments
 3. **Testing**: Python 3.13 test suite
 4. **Building**: Package building and validation
 5. **Coverage**: Automatic upload to Codecov

--- a/changelog.d/20260802_issue_45_changelog_check.md
+++ b/changelog.d/20260802_issue_45_changelog_check.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Require source-changing pull requests to include a changelog fragment.
+
+### Security
+
+- Pass the pull request base branch to the changelog check as quoted data instead
+  of interpolating it into the shell script.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -92,7 +92,8 @@ def assert_action_pin_absent(workflow: str, action: str, version: str) -> None:
 def test_workflow_run_blocks_do_not_interpolate_untrusted_inputs() -> None:
     """Contributor-controlled inputs must reach shell scripts through env vars."""
     unsafe_expression = re.compile(
-        r"\$\{\{\s*(?:inputs\.|github\.event\.inputs\.|github\.head_ref)[^}]*\}\}"
+        r"\$\{\{\s*(?:inputs\.|github\.event\.inputs\.|github\.(?:base|head)_ref)"
+        r"[^}]*\}\}"
     )
 
     for path in sorted(WORKFLOWS.glob("*.y*ml")):
@@ -102,6 +103,22 @@ def test_workflow_run_blocks_do_not_interpolate_untrusted_inputs() -> None:
                 f"{path.name} interpolates an untrusted expression in a run block:\n"
                 f"{run_block}"
             )
+
+
+def test_changelog_check_safely_requires_a_fragment() -> None:
+    """Source-changing pull requests must fail safely without a fragment."""
+    workflow = read_workflow("release.yml")
+    changelog_job = workflow_job_block(workflow, "changelog")
+    check_step = workflow_step_block(changelog_job, "Check for changelog fragments")
+
+    assert "GITHUB_BASE_REF: ${{ github.base_ref }}" in check_step
+    assert "set -euo pipefail" in check_step
+    assert 'git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD"' in check_step
+    assert 'grep -cE "$SOURCE_PATTERN" || true' in check_step
+    assert "::error::No changelog fragment found." in check_step
+    assert "::warning::No changelog fragment found." not in check_step
+    assert "exit 1" in check_step
+    assert "exit 0" not in check_step
 
 
 def test_release_workflow_separates_check_and_write_concurrency() -> None:


### PR DESCRIPTION
## Summary

- pass `github.base_ref` through the changelog step environment and quote the resulting refspec so branch names remain shell data
- enable strict shell handling and make the no-source-match case safe under `pipefail`
- fail with an error when source changes have no changelog fragment
- document the enforced policy and add a security/fix changelog fragment

## Reproduction

Before this change, the workflow embedded `${{ github.base_ref }}` directly in a Bash command. A pull request targeting a branch such as `$(touch /tmp/pwned)` therefore produced executable command substitution in the runner script. The same step emitted only a warning and exited `0` when source files changed without a fragment.

## Regression tests

`tests/test_workflows.py` now:

- treats both `github.base_ref` and `github.head_ref` as untrusted expressions that must not occur in `run:` blocks
- verifies the changelog step uses an environment variable, a quoted refspec, strict shell mode, safe source counting, an error annotation, and `exit 1`

The new assertions failed against the original workflow and pass with this fix.

## Verification

- `pytest` — 63 passed
- `ruff check .`
- `ruff format --check .`
- `mypy src/`
- `python scripts/check_file_size.py`
- `git diff --check`

Fixes #45
