### PR TITLE
fix: pin mypy below 2.0 for Python 3.9

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-02T20:34:08.964Z for PR creation at branch issue-44-ac3e192dd44c for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/44

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-02T20:34:08.964Z for PR creation at branch issue-44-ac3e192dd44c for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/44

--- a/changelog.d/20260802_issue_44_mypy_python_39.md
+++ b/changelog.d/20260802_issue_44_mypy_python_39.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Keep the development mypy version below 2.0 while the template supports and
+  type-checks against Python 3.9.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "ruff>=0.8.0,<0.9",
-    "mypy>=1.13.0",
+    "mypy>=1.13.0,<2.0",
     "pytest>=8.3.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -13,9 +13,7 @@ def dev_requirement(name: str) -> Requirement:
     """Return one requirement from the project's ``dev`` dependency group."""
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     dev_group = pyproject.split("dev = [", maxsplit=1)[1].split("]", maxsplit=1)[0]
-    requirement_lines = (
-        line.strip().strip('",') for line in dev_group.splitlines()
-    )
+    requirement_lines = (line.strip().strip('",') for line in dev_group.splitlines())
     requirements = (Requirement(line) for line in requirement_lines if line)
     return next(requirement for requirement in requirements if requirement.name == name)
 

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,0 +1,28 @@
+"""Regression tests for project package metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def dev_requirement(name: str) -> Requirement:
+    """Return one requirement from the project's ``dev`` dependency group."""
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    dev_group = pyproject.split("dev = [", maxsplit=1)[1].split("]", maxsplit=1)[0]
+    requirement_lines = (
+        line.strip().strip('",') for line in dev_group.splitlines()
+    )
+    requirements = (Requirement(line) for line in requirement_lines if line)
+    return next(requirement for requirement in requirements if requirement.name == name)
+
+
+def test_mypy_dependency_supports_configured_python_target() -> None:
+    """The dev extra must not install mypy versions that reject Python 3.9."""
+    mypy = dev_requirement("mypy")
+
+    assert "1.13.0" in mypy.specifier
+    assert "2.0" not in mypy.specifier


### PR DESCRIPTION
## Summary

- constrain the dev dependency to mypy>=1.13.0,<2.0 while the template targets Python 3.9
- add a project-metadata regression test that rejects mypy 2.x
- document the compatibility fix in a changelog fragment

## Reproduction

A fresh pip install -e ".[dev]" previously resolved mypy 2.3.0. The new focused test then failed because mypy 2.0 was allowed by the dev requirement, matching the Python 3.9 compatibility warning reported in issue 44.

## Verification

- fresh dev install resolves mypy 1.20.2
- mypy src succeeds against the configured Python 3.9 target
- pytest -v --cov=src --cov-report=xml --cov-report=term (64 passed, 100% package coverage)
- ruff check .
- ruff format --check .
- python scripts/check_file_size.py
- python -m build
- twine check dist/*
- secretlint scan
- git diff --check origin/main...HEAD

Fixes #44
