### PR TITLE
feat(ci): publish multi-architecture Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,6 +461,9 @@ jobs:
   auto-release:
     name: Auto Release
     needs: [lint, test, build]
+    outputs:
+      released: ${{ steps.github_release.outputs.released }}
+      version: ${{ steps.github_release.outputs.version }}
     concurrency:
       group: ${{ github.workflow }}-main-write
       cancel-in-progress: false
@@ -555,19 +558,26 @@ jobs:
             --version "${{ steps.version_check.outputs.current_version }}"
 
       - name: Create GitHub Release
+        id: github_release
         if: steps.version_check.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version_check.outputs.current_version }}
         run: |
           python "${{ steps.python_layout.outputs.root }}/scripts/create_github_release.py" \
-            --version "${{ steps.version_check.outputs.current_version }}" \
+            --version "$RELEASE_VERSION" \
             --repository "${{ github.repository }}" \
             --repository-root "."
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
 
   # Manual release via workflow_dispatch - only after CI passes
   manual-release:
     name: Manual Release
     needs: [lint, test, build]
+    outputs:
+      released: ${{ steps.github_release.outputs.released }}
+      version: ${{ steps.github_release.outputs.version }}
     concurrency:
       group: ${{ github.workflow }}-main-write
       cancel-in-progress: false
@@ -683,14 +693,160 @@ jobs:
             --version "${{ steps.version.outputs.new_version }}"
 
       - name: Create GitHub Release
+        id: github_release
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.new_version }}
         run: |
           python "${{ steps.python_layout.outputs.root }}/scripts/create_github_release.py" \
-            --version "${{ steps.version.outputs.new_version }}" \
+            --version "$RELEASE_VERSION" \
             --repository "${{ github.repository }}" \
             --repository-root "."
+          echo "released=true" >> "$GITHUB_OUTPUT"
+          echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+  # Optional Docker Hub publishing after the GitHub release exists. Set the
+  # DOCKERHUB_IMAGE and DOCKERHUB_USERNAME repository variables and the
+  # DOCKERHUB_TOKEN secret to enable it in repositories that ship a Dockerfile.
+  docker-publish-config:
+    name: Configure Docker Hub Publish
+    needs: [auto-release, manual-release]
+    if: |
+      !cancelled() && (
+        needs.auto-release.outputs.released == 'true' ||
+        needs.manual-release.outputs.released == 'true'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      enabled: ${{ steps.config.outputs.enabled }}
+      image: ${{ steps.config.outputs.image }}
+      version: ${{ steps.config.outputs.version }}
+    env:
+      DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      RELEASE_VERSION: ${{ needs.auto-release.outputs.version || needs.manual-release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check Docker publish configuration
+        id: config
+        run: |
+          if [ ! -f Dockerfile ]; then
+            echo "::notice::Skipping Docker publish because no Dockerfile is present"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$DOCKERHUB_IMAGE" ] || [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_TOKEN" ]; then
+            echo "::notice::Skipping Docker publish because Docker Hub is not configured"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "image=$DOCKERHUB_IMAGE" >> "$GITHUB_OUTPUT"
+            echo "version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Native runners build both architectures in parallel and push immutable
+  # digests. This avoids the performance and reliability cost of QEMU.
+  docker-publish-build:
+    name: Build Docker Image (${{ matrix.platform }})
+    needs: [docker-publish-config]
+    if: needs.docker-publish-config.outputs.enabled == 'true'
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push platform image by digest
+        id: docker_build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+          outputs: type=image,name=${{ needs.docker-publish-config.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export image digest
+        env:
+          DIGEST: ${{ steps.docker_build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload image digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: docker-digest-${{ strategy.job-index }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-publish:
+    name: Publish Multi-Architecture Docker Image
+    needs: [docker-publish-config, docker-publish-build]
+    if: needs.docker-publish-build.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download image digests
+        uses: actions/download-artifact@v7
+        with:
+          path: /tmp/digests
+          pattern: docker-digest-*
+          merge-multiple: true
+
+      - name: Create multi-architecture manifest
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ${{ needs.docker-publish-config.outputs.image }}
+          VERSION: ${{ needs.docker-publish-config.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${IMAGE}:latest" \
+            --tag "${IMAGE}:${VERSION}" \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Verify multi-architecture manifest
+        env:
+          IMAGE: ${{ needs.docker-publish-config.outputs.image }}
+          VERSION: ${{ needs.docker-publish-config.outputs.version }}
+        run: |
+          MANIFEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}")
+          grep -q "linux/amd64" <<< "$MANIFEST"
+          grep -q "linux/arm64" <<< "$MANIFEST"
 
   # A job killed by timeout-minutes concludes "cancelled", not "failure".
   # Observe every other job so that state cannot silently hide a broken run.
@@ -700,7 +856,8 @@ jobs:
     timeout-minutes: 5
     if: always()
     needs: [detect-changes, lint, test, build, changelog, docker-build,
-            auto-release, manual-release]
+            auto-release, manual-release, docker-publish-config,
+            docker-publish-build, docker-publish]
     steps:
       - uses: actions/checkout@v6
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T08:21:14.029Z for PR creation at branch issue-55-de81cecbb08a for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/55

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T08:21:14.029Z for PR creation at branch issue-55-de81cecbb08a for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/55

--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ The release workflow (`release.yml`) provides:
 6. **Published package smoke test**: Installs the just-published PyPI package
    into a clean virtualenv and verifies imports/console scripts
 7. **GitHub releases**: Automatic creation with CHANGELOG content
+8. **Optional multi-architecture Docker images**: When a `Dockerfile` exists,
+   set the `DOCKERHUB_IMAGE` and `DOCKERHUB_USERNAME` repository variables and
+   the `DOCKERHUB_TOKEN` secret to publish native `linux/amd64` and
+   `linux/arm64` images after each GitHub release
 
 **Important**: All releases require passing CI checks (lint + test + build). No release will ever happen without passing tests, ensuring code quality and stability.
 

--- a/changelog.d/20260812_issue_55_multi_arch_docker.md
+++ b/changelog.d/20260812_issue_55_multi_arch_docker.md
@@ -1,0 +1,5 @@
+### Added
+
+- Publish optional Docker Hub release images for `linux/amd64` and
+  `linux/arm64` using parallel native runners and a verified multi-architecture
+  manifest.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -487,6 +487,55 @@ def test_release_workflow_builds_docker_images_on_pull_requests() -> None:
     assert "cache-to: type=gha,mode=max" in block
 
 
+def test_release_workflow_publishes_multi_arch_docker_images() -> None:
+    """Released Docker images must use native amd64 and arm64 runners."""
+    workflow = read_workflow("release.yml")
+    config = workflow_job_block(workflow, "docker-publish-config")
+    build = workflow_job_block(workflow, "docker-publish-build")
+    publish = workflow_job_block(workflow, "docker-publish")
+
+    assert "needs: [auto-release, manual-release]" in config
+    assert "DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}" in config
+    assert "DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}" in config
+    assert "DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}" in config
+    assert "if [ ! -f Dockerfile ]" in config
+
+    assert "fail-fast: false" in build
+    assert "platform: linux/amd64" in build
+    assert "runner: ubuntu-latest" in build
+    assert "platform: linux/arm64" in build
+    assert "runner: ubuntu-24.04-arm" in build
+    assert "runs-on: ${{ matrix.runner }}" in build
+    assert "platforms: ${{ matrix.platform }}" in build
+    assert "cache-from: type=gha,scope=${{ matrix.platform }}" in build
+    assert "cache-to: type=gha,mode=max,scope=${{ matrix.platform }}" in build
+    assert "push-by-digest=true" in build
+    assert "name-canonical=true" in build
+    assert "uses: actions/upload-artifact@v7" in build
+
+    assert "uses: actions/download-artifact@v7" in publish
+    assert "merge-multiple: true" in publish
+    assert "docker buildx imagetools create" in publish
+    assert '--tag "${IMAGE}:latest"' in publish
+    assert '--tag "${IMAGE}:${VERSION}"' in publish
+    assert "docker/setup-qemu-action" not in workflow
+
+
+def test_docker_publish_follows_github_release_creation() -> None:
+    """Image publication must only start after a GitHub release succeeds."""
+    workflow = read_workflow("release.yml")
+    config = workflow_job_block(workflow, "docker-publish-config")
+
+    for release_job in ("auto-release", "manual-release"):
+        block = workflow_job_block(workflow, release_job)
+        assert "- name: Create GitHub Release" in block
+        assert "released: ${{ steps.github_release.outputs.released }}" in block
+        assert "version: ${{ steps.github_release.outputs.version }}" in block
+
+    assert "needs.auto-release.outputs.released == 'true'" in config
+    assert "needs.manual-release.outputs.released == 'true'" in config
+
+
 def test_manual_release_requires_required_checks_to_succeed() -> None:
     """Manual release must only run after lint, test, and build succeed."""
     workflow = read_workflow("release.yml")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -304,10 +304,10 @@ def test_release_workflow_action_versions_are_current() -> None:
     """Release workflow actions should use the current major versions."""
     release_workflow = read_workflow("release.yml")
 
-    assert_action_pin_count(release_workflow, "actions/checkout", "v6", 9)
+    assert_action_pin_count(release_workflow, "actions/checkout", "v6", 11)
     assert_action_pin_count(release_workflow, "actions/setup-python", "v6", 7)
-    assert_action_pin_count(release_workflow, "actions/upload-artifact", "v7", 1)
-    assert_action_pin_count(release_workflow, "actions/download-artifact", "v7", 1)
+    assert_action_pin_count(release_workflow, "actions/upload-artifact", "v7", 2)
+    assert_action_pin_count(release_workflow, "actions/download-artifact", "v7", 2)
     assert_action_pin_count(release_workflow, "codecov/codecov-action", "v7", 1)
 
     assert_action_pin_absent(release_workflow, "actions/setup-python", "v5")
@@ -518,6 +518,9 @@ def test_release_workflow_publishes_multi_arch_docker_images() -> None:
     assert "docker buildx imagetools create" in publish
     assert '--tag "${IMAGE}:latest"' in publish
     assert '--tag "${IMAGE}:${VERSION}"' in publish
+    assert "docker buildx imagetools inspect" in publish
+    assert 'grep -q "linux/amd64"' in publish
+    assert 'grep -q "linux/arm64"' in publish
     assert "docker/setup-qemu-action" not in workflow
 
 


### PR DESCRIPTION
## Summary

- add optional Docker Hub publishing after automatic or manual GitHub releases
- build `linux/amd64` and `linux/arm64` images in parallel on native GitHub-hosted runners
- push immutable per-platform digests, merge them into versioned and `latest` manifest tags, and verify both architectures
- keep generated repositories without a Dockerfile or Docker Hub configuration on a clean no-op path
- document the required repository variables and secret

## Reproduction

Before this change, `.github/workflows/release.yml` had no Docker release-publishing jobs and its only `docker/build-push-action` invocation was the pull-request smoke build. The new focused regression tests failed because `docker-publish-config`, `docker-publish-build`, and `docker-publish` did not exist.

## Implementation

`auto-release` and `manual-release` now expose a version only after `Create GitHub Release` succeeds. The Docker configuration job consumes that output and enables publication only when a root `Dockerfile`, `DOCKERHUB_IMAGE`, `DOCKERHUB_USERNAME`, and `DOCKERHUB_TOKEN` are all present.

The build matrix uses `ubuntu-latest` for `linux/amd64` and `ubuntu-24.04-arm` for `linux/arm64`; no QEMU emulation is used. Each runner pushes by digest with architecture-scoped GHA caching. A final job downloads both digest artifacts, creates `latest` and versioned manifests, and inspects the published manifest for both target platforms.

## Verification

- `pytest --cov=src --cov-report=xml --cov-report=term` — 73 passed, 100% package coverage
- `ruff check .`
- `ruff format --check .`
- `mypy src/`
- `python scripts/check_file_size.py`
- Ruby YAML parse of `.github/workflows/release.yml`
- tracked-file Secretlint scan
- `git diff --check origin/main...HEAD`

Fixes #55
