### PR TITLE
fix(ci): fail archived broken live links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -64,14 +64,14 @@ jobs:
         env:
           LYCHEE_OUTPUT: lychee/out.md
 
-      - name: Fail if broken links found and no web archive fallback
-        if: steps.lychee.outputs.exit_code != 0 && steps.webarchive.outputs.all_archived != 'true'
+      - name: Fail if broken links were found
+        if: always() && steps.lychee.outputs.exit_code != 0
         run: |
-          echo "::error::Broken links were detected with no Web Archive fallback available."
+          echo "::error::Broken live links were detected."
           echo ""
           echo "What happened:"
           echo "  lychee found one or more broken links in the *.md and *.html files of this repository."
-          echo "  The Web Archive check found no archived versions for some of them."
+          echo "  An available Web Archive snapshot is a suggested replacement; it does not make the live link valid."
           echo ""
           echo "How to fix:"
           echo "  1. Review the 'Check links with lychee' step above for the broken links."

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-12T08:27:23.951Z for PR creation at branch issue-54-4596c828ef2e for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/54

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-12T08:27:23.951Z for PR creation at branch issue-54-4596c828ef2e for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/54

--- a/changelog.d/20260812_issue_54_archived_broken_links.md
+++ b/changelog.d/20260812_issue_54_archived_broken_links.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fail broken-link validation for dead live URLs even when Web Archive snapshots are available.

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -144,9 +144,7 @@ def test_links_workflow_fails_for_every_broken_live_link() -> None:
     archive_step = workflow_step_block(
         link_job, "Check broken links against Web Archive"
     )
-    failure_step = workflow_step_block(
-        link_job, "Fail if broken links were found"
-    )
+    failure_step = workflow_step_block(link_job, "Fail if broken links were found")
 
     assert "- '**.md'" in workflow
     assert "- '**.html'" in workflow

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -136,8 +136,8 @@ def test_security_workflow_scans_code_actions_and_dependencies() -> None:
     assert "comment-summary-in-pr: on-failure" in dependency_job
 
 
-def test_links_workflow_checks_docs_with_web_archive_fallback() -> None:
-    """Markdown and HTML changes must trigger the bounded broken-link check."""
+def test_links_workflow_fails_for_every_broken_live_link() -> None:
+    """Archived snapshots must not make broken live links pass validation."""
     workflow = read_workflow("links.yml")
     link_job = workflow_job_block(workflow, "link-checker")
     lychee_step = workflow_step_block(link_job, "Check links with lychee")
@@ -145,7 +145,7 @@ def test_links_workflow_checks_docs_with_web_archive_fallback() -> None:
         link_job, "Check broken links against Web Archive"
     )
     failure_step = workflow_step_block(
-        link_job, "Fail if broken links found and no web archive fallback"
+        link_job, "Fail if broken links were found"
     )
 
     assert "- '**.md'" in workflow
@@ -161,7 +161,8 @@ def test_links_workflow_checks_docs_with_web_archive_fallback() -> None:
     assert "output: lychee/out.md" in lychee_step
     assert "if: steps.lychee.outputs.exit_code != 0" in archive_step
     assert "python scripts/check_web_archive.py" in archive_step
-    assert "steps.webarchive.outputs.all_archived != 'true'" in failure_step
+    assert "if: always() && steps.lychee.outputs.exit_code != 0" in failure_step
+    assert "all_archived" not in failure_step
     assert "exit 1" in failure_step
 
 


### PR DESCRIPTION
## Summary

- fail broken-link validation whenever Lychee reports a broken live URL
- retain Web Archive checks as actionable replacement diagnostics only
- run the terminal explanation with `always()` so helper failures cannot hide Lychee failures
- add a workflow-policy regression test and changelog fragment

## Reproduction

Before this fix, a Lychee report containing a dead URL with an available Wayback snapshot caused `check_web_archive.py` to emit `all_archived=true`. The final workflow condition required both a nonzero Lychee exit and `all_archived != true`, so the failure step was skipped and CI passed while the source still referenced the dead live URL.

The regression test was added first and failed against the old workflow because the required unconditional failure step did not exist.

## Verification

- `pytest tests/test_workflows.py tests/test_check_web_archive.py -q`
- `ruff check .`
- `ruff format --check .`
- `mypy src/`
- `python scripts/check_file_size.py`
- `pytest --cov=src --cov-report=term` (71 passed, 100% package coverage)
- `sphinx-build -W --keep-going -b html docs /tmp/issue54-docs-build`

Fixes #54