### PR TITLE
Add continuous vulnerability auditing for Python dependencies

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,24 @@ permissions:
   contents: read
 
 jobs:
+  dependency-audit:
+    name: Audit Resolved Python Dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: check-${{ github.workflow }}-${{ github.ref }}-dependency-audit
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Audit pyproject.toml and docs/requirements.txt
+        run: python scripts/audit_dependencies.py
+
   codeql:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-16T00:13:02.696Z for PR creation at branch issue-58-f8d359692214 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/58

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-16T00:13:02.696Z for PR creation at branch issue-58-f8d359692214 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/58

--- a/changelog.d/20260816_issue_58_dependency_audit.md
+++ b/changelog.d/20260816_issue_58_dependency_audit.md
@@ -1,0 +1,4 @@
+### Security
+
+- Audit the complete resolved Python dependency set on pushes, pull requests,
+  and a weekly schedule with pinned `pip-audit` tooling.

--- a/scripts/audit_dependencies.py
+++ b/scripts/audit_dependencies.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Resolve and audit every Python dependency surface supported by the template."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+PIP_AUDIT_VERSION = "2.10.1"
+DEPENDENCY_SURFACES = ("pyproject.toml", "docs/requirements.txt")
+
+
+def run(command: list[str], *, cwd: Path) -> str:
+    """Run a command, failing the audit when dependency resolution fails."""
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    output = completed.stdout.strip()
+    if output:
+        print(output)
+    return output
+
+
+def python_executable(venv: Path) -> Path:
+    """Return the Python executable for a virtual environment."""
+    scripts_directory = "Scripts" if sys.platform == "win32" else "bin"
+    executable = "python.exe" if sys.platform == "win32" else "python"
+    return venv / scripts_directory / executable
+
+
+def project_install_target(project_root: Path) -> str:
+    """Build an install target that resolves every declared optional extra."""
+    pyproject_path = project_root / "pyproject.toml"
+    with pyproject_path.open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+    extras = sorted(pyproject.get("project", {}).get("optional-dependencies", {}))
+    return f".[{','.join(extras)}]" if extras else "."
+
+
+def audit_dependencies(project_root: Path) -> None:
+    """Resolve application dependencies in isolation and audit the result."""
+    missing = [
+        surface
+        for surface in DEPENDENCY_SURFACES
+        if not (project_root / surface).is_file()
+    ]
+    if missing:
+        message = f"Unmapped or missing dependency surfaces: {', '.join(missing)}"
+        raise FileNotFoundError(message)
+
+    with tempfile.TemporaryDirectory(prefix="dependency-audit-") as temporary:
+        temporary_root = Path(temporary)
+        target_venv = temporary_root / "target"
+        audit_venv = temporary_root / "audit"
+        run([sys.executable, "-m", "venv", str(target_venv)], cwd=project_root)
+        run([sys.executable, "-m", "venv", str(audit_venv)], cwd=project_root)
+
+        target_python = python_executable(target_venv)
+        audit_python = python_executable(audit_venv)
+        run(
+            [
+                str(target_python),
+                "-m",
+                "pip",
+                "install",
+                project_install_target(project_root),
+            ],
+            cwd=project_root,
+        )
+        run(
+            [
+                str(target_python),
+                "-m",
+                "pip",
+                "install",
+                "-r",
+                "docs/requirements.txt",
+            ],
+            cwd=project_root,
+        )
+        run(
+            [
+                str(audit_python),
+                "-m",
+                "pip",
+                "install",
+                f"pip-audit=={PIP_AUDIT_VERSION}",
+            ],
+            cwd=project_root,
+        )
+        site_packages = run(
+            [
+                str(target_python),
+                "-c",
+                "import sysconfig; print(sysconfig.get_paths()['purelib'])",
+            ],
+            cwd=project_root,
+        )
+        run(
+            [
+                str(audit_python),
+                "-m",
+                "pip_audit",
+                "--path",
+                site_packages,
+                "--skip-editable",
+            ],
+            cwd=project_root,
+        )
+
+
+if __name__ == "__main__":
+    audit_dependencies(Path(__file__).resolve().parents[1])

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -140,8 +140,12 @@ def test_security_workflow_scans_code_actions_and_dependencies() -> None:
     assert "uses: actions/checkout@v6" in audit_job
     assert "uses: actions/setup-python@v6" in audit_job
     assert "python scripts/audit_dependencies.py" in audit_job
-    assert "pip-audit==2.10.1" in audit_job
     assert "if: github.event_name == 'pull_request'" not in audit_job
+
+    audit_script = (ROOT / "scripts" / "audit_dependencies.py").read_text(
+        encoding="utf-8"
+    )
+    assert 'PIP_AUDIT_VERSION = "2.10.1"' in audit_script
 
 
 def test_dependency_audit_maps_every_declared_surface() -> None:
@@ -152,9 +156,9 @@ def test_dependency_audit_maps_every_declared_surface() -> None:
     assert dependency_surfaces
     for surface in dependency_surfaces:
         relative_surface = surface.relative_to(ROOT).as_posix()
-        assert relative_surface in script, (
-            f"Dependency surface {relative_surface!r} has no audit mapping"
-        )
+        assert (
+            relative_surface in script
+        ), f"Dependency surface {relative_surface!r} has no audit mapping"
 
 
 def test_links_workflow_fails_for_every_broken_live_link() -> None:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -112,6 +112,7 @@ def test_security_workflow_scans_code_actions_and_dependencies() -> None:
     workflow = read_workflow("security.yml")
     codeql_job = workflow_job_block(workflow, "codeql")
     dependency_job = workflow_job_block(workflow, "dependency-review")
+    audit_job = workflow_job_block(workflow, "dependency-audit")
 
     assert "branches: [main]" in workflow
     assert "pull_request:" in workflow
@@ -134,6 +135,26 @@ def test_security_workflow_scans_code_actions_and_dependencies() -> None:
     assert "uses: actions/dependency-review-action@v5" in dependency_job
     assert "fail-on-severity: high" in dependency_job
     assert "comment-summary-in-pr: on-failure" in dependency_job
+
+    assert "timeout-minutes: 15" in audit_job
+    assert "uses: actions/checkout@v6" in audit_job
+    assert "uses: actions/setup-python@v6" in audit_job
+    assert "python scripts/audit_dependencies.py" in audit_job
+    assert "pip-audit==2.10.1" in audit_job
+    assert "if: github.event_name == 'pull_request'" not in audit_job
+
+
+def test_dependency_audit_maps_every_declared_surface() -> None:
+    """Every dependency declaration in the template must be audited."""
+    script = (ROOT / "scripts" / "audit_dependencies.py").read_text(encoding="utf-8")
+    dependency_surfaces = [ROOT / "pyproject.toml", *ROOT.rglob("requirements*.txt")]
+
+    assert dependency_surfaces
+    for surface in dependency_surfaces:
+        relative_surface = surface.relative_to(ROOT).as_posix()
+        assert relative_surface in script, (
+            f"Dependency surface {relative_surface!r} has no audit mapping"
+        )
 
 
 def test_links_workflow_fails_for_every_broken_live_link() -> None:


### PR DESCRIPTION
## Summary

- add a scheduled, push, and pull-request gate for vulnerabilities in resolved Python dependencies
- resolve all `pyproject.toml` optional extras and `docs/requirements.txt` in an isolated target environment
- pin `pip-audit` 2.10.1 in a separate tool environment so scanner dependencies do not contaminate audit results
- enforce workflow coverage for every declared dependency surface with a regression test

## Reproduction

Before this change, `.github/workflows/security.yml` ran dependency review only for pull requests. A new advisory affecting an unchanged dependency therefore had no continuous gate.

## Verification

- `python scripts/audit_dependencies.py` (`No known vulnerabilities found`)
- `pytest --cov=src --cov-report=term` (74 passed, 100% package coverage)
- `ruff check .`
- `ruff format --check .`
- `mypy src/`
- `python scripts/check_file_size.py`

Fixes #58