### PR TITLE
Give long pipeline steps their own execution budget so a timeout reports `failure`, not `cancelled`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,10 +151,16 @@ jobs:
           echo "Detected Python layout: root=$PYTHON_ROOT, multi_language=$MULTI_LANGUAGE"
 
       - name: Install dependencies
+        env:
+          INSTALL_BUDGET_SECONDS: 300
         run: |
           cd "${{ steps.python_layout.outputs.root }}"
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          bash scripts/run-with-budget-warning.sh \
+            "$INSTALL_BUDGET_SECONDS" "Install dependencies" \
+            bash -euo pipefail -c '
+              python -m pip install --upgrade pip
+              pip install -e ".[dev]"
+            '
 
       - name: Run Ruff linting
         run: |
@@ -177,7 +183,12 @@ jobs:
           python scripts/check_file_size.py
 
       - name: Check for secrets
-        run: npx --yes -p secretlint -p @secretlint/secretlint-rule-preset-recommend secretlint "**/*"
+        env:
+          SECRETLINT_BUDGET_SECONDS: 300
+        run: |
+          bash scripts/run-with-budget-warning.sh \
+            "$SECRETLINT_BUDGET_SECONDS" "Check for secrets" \
+            npx --yes -p secretlint -p @secretlint/secretlint-rule-preset-recommend secretlint "**/*"
 
   # === TEST ===
   # Test on latest Python version only
@@ -232,15 +243,25 @@ jobs:
           echo "Detected Python layout: root=$PYTHON_ROOT, multi_language=$MULTI_LANGUAGE"
 
       - name: Install dependencies
+        env:
+          INSTALL_BUDGET_SECONDS: 300
         run: |
           cd "${{ steps.python_layout.outputs.root }}"
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          bash scripts/run-with-budget-warning.sh \
+            "$INSTALL_BUDGET_SECONDS" "Install dependencies" \
+            bash -euo pipefail -c '
+              python -m pip install --upgrade pip
+              pip install -e ".[dev]"
+            '
 
       - name: Run tests
+        env:
+          TEST_BUDGET_SECONDS: 900
         run: |
           cd "${{ steps.python_layout.outputs.root }}"
-          pytest tests/ -v --cov=src --cov-report=xml --cov-report=term
+          bash scripts/run-with-budget-warning.sh \
+            "$TEST_BUDGET_SECONDS" "Run tests" \
+            pytest tests/ -v --cov=src --cov-report=xml --cov-report=term
 
       - name: Report skipped Codecov upload
         if: env.CODECOV_TOKEN == ''
@@ -446,6 +467,7 @@ jobs:
 
       - name: Build Docker image (no push)
         if: steps.dockerfile.outputs.exists == 'true'
+        timeout-minutes: 40
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -780,6 +802,7 @@ jobs:
 
       - name: Build and push platform image by digest
         id: docker_build
+        timeout-minutes: 40
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
         env:
           SECRETLINT_BUDGET_SECONDS: 300
         run: |
-          bash scripts/run-with-budget-warning.sh \
+          bash "${{ steps.python_layout.outputs.root }}/scripts/run-with-budget-warning.sh" \
             "$SECRETLINT_BUDGET_SECONDS" "Check for secrets" \
             npx --yes -p secretlint -p @secretlint/secretlint-rule-preset-recommend secretlint "**/*"
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-08-20T04:56:54.559Z for PR creation at branch issue-60-1431435e7081 for issue https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/60

--- a/changelog.d/20260820_issue_60_step_execution_budgets.md
+++ b/changelog.d/20260820_issue_60_step_execution_budgets.md
@@ -1,0 +1,15 @@
+### Added
+
+- Added `scripts/run-with-budget-warning.sh`, which runs a command under an
+  execution budget that expires before the job clock: it warns at 70% of the
+  budget, terminates the whole process group at the deadline, exits `124`, and
+  emits an `::error` annotation naming the budget that was blown.
+
+### Fixed
+
+- Budgeted the long release steps (dependency installation, secret scanning,
+  the test run and both Docker image builds) so an overrun reports `failure`
+  with a named budget instead of the `cancelled` conclusion GitHub gives a job
+  killed by `timeout-minutes` — which on a pull request produced no failure at
+  all. `timeout-minutes` now serves only as a backstop, and a regression test
+  keeps every step deadline at or below 70% of the cap it sits under.

--- a/scripts/run-with-budget-warning.sh
+++ b/scripts/run-with-budget-warning.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Run a command under an execution budget that expires before the job clock.
+#
+# GitHub reports a job killed by `timeout-minutes` as **cancelled**, not
+# **failed** (issue #50), so a step that is allowed to run until the runner
+# kills it converts a real, actionable timeout into a benign-looking
+# cancellation: red on `main`, and only a warning on a pull request, where a
+# cancellation is normally just a superseded run.
+#
+# This wrapper owns the deadline instead of the runner. It warns while the
+# command can still be acted on and -- unless enforcement is explicitly
+# disabled -- terminates the command at the budget and exits 124, so the job
+# reports `failure` with an ::error annotation naming the budget it blew.
+#
+# `timeout-minutes` stays in place as a backstop, never as the deadline.
+#
+# Usage: run-with-budget-warning.sh <budget-seconds> <label> <command> [args...]
+#
+# Environment:
+#   BUDGET_WARN_RATIO_PERCENT  warn once this share of the budget is spent (70)
+#   BUDGET_ENFORCE             `false` warns only and never terminates (true)
+#   BUDGET_GRACE_SECONDS       SIGTERM -> SIGKILL grace period (15)
+#   BUDGET_POLL_SECONDS        deadline polling interval (1)
+#   BUDGET_HEARTBEAT_SECONDS   spacing of the verbose progress lines (60)
+#   CI_VERBOSE                 `true` prints those progress lines (false)
+set -euo pipefail
+
+budget_seconds="${1:?budget seconds are required}"
+label="${2:?a warning label is required}"
+shift 2
+[ "$#" -gt 0 ] || {
+  echo "a command is required" >&2
+  exit 2
+}
+
+warn_ratio="${BUDGET_WARN_RATIO_PERCENT:-70}"
+enforce="${BUDGET_ENFORCE:-true}"
+grace_seconds="${BUDGET_GRACE_SECONDS:-15}"
+poll_seconds="${BUDGET_POLL_SECONDS:-1}"
+heartbeat_seconds="${BUDGET_HEARTBEAT_SECONDS:-60}"
+verbose="${CI_VERBOSE:-false}"
+
+threshold=$((budget_seconds * warn_ratio / 100))
+[ "$threshold" -gt 0 ] || threshold=1
+started=$SECONDS
+
+# Job control gives the command its own process group, so the whole process
+# tree can be signalled at the deadline instead of only its root. `pytest -n`
+# (xdist) and `pip` both spawn children that would otherwise outlive a kill
+# aimed at the direct child alone -- which is why `timeout(1)` is not enough.
+set -m
+"$@" &
+command_pid=$!
+set +m
+
+signal_command_tree() {
+  local signal="$1"
+  kill "-$signal" "-$command_pid" 2> /dev/null ||
+    kill "-$signal" "$command_pid" 2> /dev/null ||
+    true
+}
+
+# shellcheck disable=SC2329  # invoked indirectly by the trap below
+forward_cancellation() {
+  signal_command_tree TERM
+}
+trap forward_cancellation INT TERM
+
+warned=false
+terminated=false
+last_heartbeat=0
+
+while kill -0 "$command_pid" 2> /dev/null; do
+  elapsed=$((SECONDS - started))
+
+  if [ "$warned" = false ] && [ "$elapsed" -ge "$threshold" ]; then
+    warned=true
+    echo "::warning title=${label} is approaching its timeout::The command is still running after ${elapsed}s (${warn_ratio}% of its ${budget_seconds}s execution budget). Speed up or split the work before the budget terminates the step." >&2
+  fi
+
+  if [ "$verbose" = true ] &&
+    [ $((elapsed - last_heartbeat)) -ge "$heartbeat_seconds" ]; then
+    last_heartbeat="$elapsed"
+    echo "[budget] ${label} has been running for ${elapsed}s of its ${budget_seconds}s budget." >&2
+  fi
+
+  if [ "$enforce" = true ] && [ "$elapsed" -ge "$budget_seconds" ]; then
+    terminated=true
+    echo "::error title=${label} exceeded its execution budget::The command was terminated after ${elapsed}s, its full ${budget_seconds}s execution budget. The budget expires before \`timeout-minutes\` so this reports as a failure instead of a cancelled job (issue #50, issue #60). Speed up or split the work, or raise the budget together with the job timeout." >&2
+    signal_command_tree TERM
+    grace_deadline=$((SECONDS + grace_seconds))
+    while kill -0 "$command_pid" 2> /dev/null && [ "$SECONDS" -lt "$grace_deadline" ]; do
+      sleep "$poll_seconds"
+    done
+    signal_command_tree KILL
+    break
+  fi
+
+  sleep "$poll_seconds"
+done
+
+set +e
+wait "$command_pid"
+status=$?
+set -e
+trap - INT TERM
+
+elapsed=$((SECONDS - started))
+if [ "$terminated" = true ]; then
+  printf '%s was terminated after %ss, its full %ss execution budget.\n' \
+    "$label" "$elapsed" "$budget_seconds"
+  exit 124
+fi
+
+printf '%s took %ss of its %ss execution budget.\n' \
+  "$label" "$elapsed" "$budget_seconds"
+exit "$status"

--- a/tests/test_run_with_budget_warning.py
+++ b/tests/test_run_with_budget_warning.py
@@ -1,0 +1,162 @@
+"""Behaviour tests for the execution-budget wrapper (issue #60).
+
+A job killed by ``timeout-minutes`` is reported by GitHub as **cancelled**, not
+**failed**, so on a pull request a genuine timeout only produces a warning. The
+wrapper exists to take the deadline away from the runner: it must terminate the
+whole process tree of an overrun, annotate it as an error naming the budget, and
+exit 124 like ``timeout(1)`` so the job concludes ``failure``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "run-with-budget-warning.sh"
+
+
+def run_wrapper(
+    arguments: list[str], **env: str
+) -> tuple[subprocess.CompletedProcess[str], float]:
+    """Run the wrapper with the given arguments and return it with its runtime."""
+    started = time.monotonic()
+    completed = subprocess.run(
+        ["bash", str(SCRIPT), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin", **env},
+    )
+    return completed, time.monotonic() - started
+
+
+def is_running(pid: int) -> bool:
+    """Return whether a process is still running, ignoring unreaped zombies.
+
+    A grandchild that outlives its parent is reparented, and an init that does
+    not reap leaves it as a zombie: terminated, but still addressable by
+    ``os.kill(pid, 0)``.
+    """
+    for _ in range(50):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        state = Path(f"/proc/{pid}/stat")
+        if state.exists():
+            return (
+                state.read_text(encoding="utf-8").rpartition(")")[2].split()[0] != "Z"
+            )
+        time.sleep(0.1)
+    return True
+
+
+def test_wrapper_is_executable_and_strict() -> None:
+    """The wrapper must be runnable directly and abort on the first error."""
+    assert SCRIPT.exists()
+    assert SCRIPT.stat().st_mode & 0o111
+    assert "set -euo pipefail" in SCRIPT.read_text(encoding="utf-8")
+
+
+def test_command_inside_its_budget_succeeds_and_reports_what_it_spent() -> None:
+    """The common case must stay quiet about failure and pass the exit code on."""
+    completed, _ = run_wrapper(["30", "Quick step", "true"])
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Quick step took" in completed.stdout
+    assert "::error" not in completed.stderr
+
+    failing, _ = run_wrapper(["30", "Quick step", "false"])
+    assert failing.returncode == 1, failing.stderr
+
+
+def test_overrun_is_terminated_and_reported_as_an_error() -> None:
+    """An overrun must fail the job instead of running into the job clock."""
+    completed, elapsed = run_wrapper(
+        ["2", "Runaway suite", "sleep", "120"],
+        BUDGET_WARN_RATIO_PERCENT="50",
+        BUDGET_GRACE_SECONDS="2",
+    )
+
+    assert completed.returncode == 124, completed.stderr
+    assert (
+        "::error title=Runaway suite exceeded its execution budget::"
+        in completed.stderr
+    )
+    assert "2s execution budget" in completed.stderr
+    assert elapsed < 60, (
+        f"the wrapper waited {elapsed:.0f}s to enforce a 2s budget; it must not "
+        "depend on the job clock to stop a runaway command"
+    )
+
+
+def test_overrun_kills_the_whole_process_tree(tmp_path: Path) -> None:
+    """`pytest -n` spawns workers, and orphans would hold the runner open."""
+    pid_file = tmp_path / "pids"
+    completed, _ = run_wrapper(
+        [
+            "2",
+            "Fan-out step",
+            "bash",
+            "-c",
+            f'echo $$ > "{pid_file}"; sleep 600 & echo $! >> "{pid_file}"; wait',
+        ],
+        BUDGET_GRACE_SECONDS="2",
+    )
+
+    assert completed.returncode == 124, completed.stderr
+    pids = [int(line) for line in pid_file.read_text(encoding="utf-8").split()]
+    assert len(pids) == 2
+    for pid in pids:
+        assert not is_running(pid), f"process {pid} outlived the budget"
+
+
+def test_warning_arrives_while_the_command_is_still_running() -> None:
+    """A post-mortem warning on a killed job is exactly the missing diagnostic."""
+    completed, _ = run_wrapper(
+        ["4", "Slow suite", "sleep", "2"], BUDGET_WARN_RATIO_PERCENT="30"
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "::warning title=Slow suite is approaching its timeout::" in completed.stderr
+
+
+def test_enforcement_has_an_escape_hatch_for_local_runs() -> None:
+    """A laptop must not be killed for being slower than a hosted runner."""
+    completed, _ = run_wrapper(
+        ["1", "Local run", "sleep", "2"],
+        BUDGET_ENFORCE="false",
+        BUDGET_WARN_RATIO_PERCENT="10",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "::warning title=Local run is approaching its timeout::" in completed.stderr
+    assert "::error" not in completed.stderr
+
+
+def test_heartbeat_is_available_but_off_by_default() -> None:
+    """Verbose tracing names the command still running when the budget expires."""
+    quiet, _ = run_wrapper(
+        ["30", "Quiet run", "sleep", "2"], BUDGET_HEARTBEAT_SECONDS="1"
+    )
+    assert quiet.returncode == 0, quiet.stderr
+    assert "[budget]" not in quiet.stderr
+
+    verbose, _ = run_wrapper(
+        ["30", "Verbose run", "sleep", "2"],
+        BUDGET_HEARTBEAT_SECONDS="1",
+        CI_VERBOSE="true",
+    )
+    assert verbose.returncode == 0, verbose.stderr
+    assert "[budget]" in verbose.stderr
+
+
+def test_missing_arguments_are_rejected() -> None:
+    """A misconfigured call must not silently run without a deadline."""
+    for arguments in ([], ["30"], ["30", "Label"]):
+        completed, _ = run_wrapper(arguments)
+        assert completed.returncode != 0
+        assert completed.returncode != 124

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -641,3 +641,122 @@ def test_docs_workflow_deploys_pages_only_when_opted_in() -> None:
     assert "::notice::" in skip_step
     assert "DEPLOY_GITHUB_PAGES=true" in skip_step
     assert "Settings -> Pages" in skip_step
+
+
+# The share of a job's `timeout-minutes` cap that its step deadlines may claim.
+# The remainder pays for the work outside them -- checkout, Python setup, cache
+# restore, artifact transfer -- plus the wrapper's SIGTERM grace. If the cap
+# expires first, GitHub reports the kill as `cancelled` rather than `failure`
+# and the overrun stops being visible on a pull request at all (issue #60).
+MAX_BUDGET_SHARE_PERCENT = 70
+
+
+def workflow_job_names(workflow: str) -> list[str]:
+    """Return every top-level job name declared by a workflow."""
+    jobs_section = workflow.split("\njobs:\n", maxsplit=1)[1]
+    return re.findall(r"^  ([A-Za-z0-9_-]+):$", jobs_section, re.MULTILINE)
+
+
+def job_timeout_minutes(job_block: str) -> int | None:
+    """Return the job-level ``timeout-minutes`` cap, if the job declares one."""
+    match = re.search(r"^    timeout-minutes: (\d+)$", job_block, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+def job_step_deadline_seconds(job_block: str) -> list[tuple[str, int]]:
+    """Return every step-level deadline in a job, as ``(source, seconds)``.
+
+    A shell step owns its deadline through ``run-with-budget-warning.sh`` and a
+    ``*_BUDGET_SECONDS`` env var; a step that runs a composite action cannot be
+    wrapped, so it owns a step-level ``timeout-minutes`` instead.
+    """
+    budgets = [
+        (name, int(seconds))
+        for name, seconds in re.findall(
+            r"^          ([A-Z0-9_]*BUDGET_SECONDS): (\d+)$", job_block, re.MULTILINE
+        )
+    ]
+    step_timeouts = [
+        (f"step timeout-minutes: {minutes}", int(minutes) * 60)
+        for minutes in re.findall(
+            r"^        timeout-minutes: (\d+)$", job_block, re.MULTILINE
+        )
+    ]
+    return budgets + step_timeouts
+
+
+def test_every_workflow_job_declares_a_timeout() -> None:
+    """A job with no cap inherits GitHub's six-hour default before cancelling."""
+    for path in sorted(WORKFLOWS.glob("*.y*ml")):
+        workflow = path.read_text(encoding="utf-8")
+        for job_name in workflow_job_names(workflow):
+            block = workflow_job_block(workflow, job_name)
+            assert job_timeout_minutes(block) is not None, (
+                f"{path.name}: job `{job_name}` declares no timeout-minutes, so it "
+                "inherits the 360-minute default and concludes `cancelled`"
+            )
+
+
+def test_step_deadlines_expire_before_the_job_timeout_they_sit_under() -> None:
+    """`timeout-minutes` is a backstop; the step deadlines must fire first."""
+    checked = 0
+
+    for path in sorted(WORKFLOWS.glob("*.y*ml")):
+        workflow = path.read_text(encoding="utf-8")
+        for job_name in workflow_job_names(workflow):
+            block = workflow_job_block(workflow, job_name)
+            deadlines = job_step_deadline_seconds(block)
+            if not deadlines:
+                continue
+
+            cap_minutes = job_timeout_minutes(block)
+            assert (
+                cap_minutes is not None
+            ), f"{path.name}: job `{job_name}` budgets a step but declares no cap"
+            checked += len(deadlines)
+
+            cap_seconds = cap_minutes * 60
+            total = sum(seconds for _, seconds in deadlines)
+            share = total * 100 // cap_seconds
+            assert share <= MAX_BUDGET_SHARE_PERCENT, (
+                f"{path.name}: job `{job_name}` gives its steps {total}s of "
+                f"deadlines ({dict(deadlines)}) under a {cap_minutes}m cap "
+                f"({share}% of it). Unbudgeted setup has to fit in the remainder, "
+                "or the job clock expires first and the overrun is reported as "
+                "`cancelled` instead of `failure` (issue #60). Keep the total at "
+                f"or below {MAX_BUDGET_SHARE_PERCENT}% of the cap."
+            )
+
+    assert checked >= 6, f"expected every budgeted step to be checked, saw {checked}"
+
+
+def test_long_release_steps_own_an_execution_deadline() -> None:
+    """The steps whose duration a remote host decides must not run unbounded."""
+    workflow = read_workflow("release.yml")
+
+    wrapped = {
+        "lint": ("Install dependencies", "Check for secrets"),
+        "test": ("Install dependencies", "Run tests"),
+    }
+    for job_name, step_names in wrapped.items():
+        block = workflow_job_block(workflow, job_name)
+        for step_name in step_names:
+            step = workflow_step_block(block, step_name)
+            assert "run-with-budget-warning.sh" in step, (
+                f"release.yml: step `{step_name}` of job `{job_name}` runs "
+                "unbounded under the job clock (issue #60)"
+            )
+            assert re.search(r"^          [A-Z0-9_]*BUDGET_SECONDS: \d+$", step, re.M)
+
+    # `uses:` steps cannot be wrapped by a shell script, so their deadline is a
+    # step-level timeout-minutes -- which GitHub reports as a failed step.
+    for job_name, step_name in (
+        ("docker-build", "Build Docker image (no push)"),
+        ("docker-publish-build", "Build and push platform image by digest"),
+    ):
+        block = workflow_job_block(workflow, job_name)
+        step = workflow_step_block(block, step_name)
+        assert re.search(r"^        timeout-minutes: \d+$", step, re.M), (
+            f"release.yml: step `{step_name}` of job `{job_name}` has no "
+            "step-level timeout, so an overrun cancels the job (issue #60)"
+        )


### PR DESCRIPTION
## Summary

`timeout-minutes` was the only deadline in the pipeline, and GitHub reports a
job killed by it as **cancelled**, not **failed**. `scripts/check-pipeline-status.sh`
turns that into an error only on `main`; on a pull request it is just a warning,
because there a cancellation is normally a superseded run. So a genuine timeout
on a pull request produced nothing red, and on `main` the error could not name
the deadline that was blown — no step owned one.

This PR gives the long steps their own deadline, so `timeout-minutes` becomes a
backstop and never the deadline.

Fixes #60

## Changes

- **`scripts/run-with-budget-warning.sh`** — runs a command under an execution
  budget:
  - `set -m` puts the command in its own **process group**, so `pytest -n`
    workers and `pip` children are signalled too instead of being orphaned onto
    the runner (which is also why `timeout(1)` alone is insufficient);
  - `::warning` at 70% of the budget, while the overrun can still be acted on;
  - at the deadline: SIGTERM to the group, a grace period, then SIGKILL;
  - `::error title=<label> exceeded its execution budget::…` and exit **124**,
    matching `timeout(1)`, so the job reports `failure` naming the budget;
  - `BUDGET_ENFORCE=false` warns without killing (local runs), and
    `CI_VERBOSE=true` adds a heartbeat naming what is still running.
- **`release.yml`** — `lint` and `test` budget **installation separately** from
  the work that follows, because a slow dependency resolve is the most common
  cause of a Python job overrun and is exactly the part a `pytest` budget cannot
  see: install 300s, secretlint 300s (cap 20m), install 300s + pytest 900s
  (cap 30m). The two Docker builds run through `uses:` actions, which a shell
  wrapper cannot own, so they get a step-level `timeout-minutes: 40` under their
  60m caps — GitHub reports a step killed by that as a **failed step**.

## Reproduction and verification

The issue's repro is a step allowed to run into the job clock:

```yaml
    timeout-minutes: 1
    steps:
      - run: sleep 120     # conclusion: cancelled, only a ::warning on a PR
```

Under the wrapper the same overrun exits 124 with an `::error`, so the job
concludes `failure`. `tests/test_run_with_budget_warning.py` asserts exactly
that, and that the process tree really dies:

```
$ bash scripts/run-with-budget-warning.sh 2 "Runaway suite" sleep 120
::warning title=Runaway suite is approaching its timeout::…
::error title=Runaway suite exceeded its execution budget::The command was terminated
after 2s, its full 2s execution budget. …
$ echo $?
124
```

## Tests

- `tests/test_run_with_budget_warning.py` — exit 124 and the `::error`
  annotation on overrun, the whole process group terminated (no zombie
  survivors), the warning arriving *while* the command is alive, exit-code
  passthrough, the `BUDGET_ENFORCE=false` escape hatch, the off-by-default
  heartbeat, and rejection of a call with no command.
- `tests/test_workflows.py` — the invariant that finds the *next* occurrence:
  every step deadline in **every** workflow must sum to at most **70%** of the
  `timeout-minutes` it sits under, leaving the remainder for unbudgeted setup;
  plus every job must declare a cap at all, and the budgeted steps must actually
  invoke the wrapper.

All 85 tests pass locally, along with `ruff check`, `ruff format --check` and
`mypy src`.
